### PR TITLE
Feature/18dof gpu

### DIFF
--- a/wheeled_vehicle_models/18dof-gpu/CMakeLists.txt
+++ b/wheeled_vehicle_models/18dof-gpu/CMakeLists.txt
@@ -23,6 +23,8 @@ endif()
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_options(-g -ggdb3)
     add_definitions(-DDEBUG)
+
+    set(CUDA_NVCC_FLAGS_DEBUG "-G -g" CACHE STRING "NVCC debug flags" FORCE)
 endif()
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_options(-O3)

--- a/wheeled_vehicle_models/18dof-gpu/CMakeLists.txt
+++ b/wheeled_vehicle_models/18dof-gpu/CMakeLists.txt
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 3.18)
+project(d18dof_gpu LANGUAGES CXX CUDA)
+# -----------------------------------------------------
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_BINARY_DIR  ${CMAKE_SOURCE_DIR}/build)
+
+# -----------------------------------------------------
+enable_language(CUDA)
+find_package(CUDA 8.0 REQUIRED)
+message(STATUS "Found CUDA ${CUDA_VERSION_STRING} at ${CUDA_TOOLKIT_ROOT_DIR}")
+set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}")
+
+
+# -----------------------------------------------------
+
+# Set Cmake build type to by default to release
+if(NOT CMAKE_BUILD_TYPE)
+ set(CMAKE_BUILD_TYPE Release)
+endif()
+
+# If specified set the CMake mode
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_compile_options(-g -ggdb3)
+    add_definitions(-DDEBUG)
+endif()
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    add_compile_options(-O3)
+endif()
+
+
+
+set(MODEL_FILES
+    dof18_gpu.cuh
+    dof18_gpu.cu
+)
+
+set(UTILS_FILES
+    ${CMAKE_SOURCE_DIR}/../utils/utils_gpu.cuh
+    ${CMAKE_SOURCE_DIR}/../utils/utils_gpu.cu
+)
+
+# Only half implicit solver available for GPU
+set(SOLVER_FILES
+  dof18_halfImplicit_gpu.cuh
+  dof18_halfImplicit_gpu.cu
+)
+
+# Build the demos
+set(HMMWV_PROGRAMS
+    demo_hmmwv
+)
+
+# -----------------------------------------------------
+
+include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_SOURCE_DIR}/../utils)
+include_directories(${CMAKE_SOURCE_DIR}/../third_party)
+
+
+# -----------------------------------------------------
+## Build HMMWV demos
+# -----------------------------------------------------
+foreach(PROGRAM ${HMMWV_PROGRAMS})
+    message(STATUS "...add ${PROGRAM}")
+    add_executable(${PROGRAM} ${CMAKE_SOURCE_DIR}/demos/HMMWV/${PROGRAM}.cu ${UTILS_FILES} ${MODEL_FILES} ${SOLVER_FILES})
+    # Enable separate compilation for CUDA
+    set_property(TARGET ${PROGRAM} PROPERTY CUDA_SEPARABLE_COMPILATION ON)
+    # Set architecure based on this link - https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
+    set_target_properties(${PROGRAM} PROPERTIES CUDA_ARCHITECTURES "60;61;70;75;80;86;89;90")
+endforeach()

--- a/wheeled_vehicle_models/18dof-gpu/CMakeLists.txt
+++ b/wheeled_vehicle_models/18dof-gpu/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SOLVER_FILES
 set(HMMWV_PROGRAMS
     demo_hmmwv
     demo_hmmwv_varControls
+    demo_hmmwv_step
 )
 
 # -----------------------------------------------------

--- a/wheeled_vehicle_models/18dof-gpu/CMakeLists.txt
+++ b/wheeled_vehicle_models/18dof-gpu/CMakeLists.txt
@@ -53,6 +53,7 @@ set(HMMWV_PROGRAMS
     demo_hmmwv
     demo_hmmwv_varControls
     demo_hmmwv_step
+    demo_hmmwv_controlsFunctor
 )
 
 # -----------------------------------------------------

--- a/wheeled_vehicle_models/18dof-gpu/CMakeLists.txt
+++ b/wheeled_vehicle_models/18dof-gpu/CMakeLists.txt
@@ -51,6 +51,7 @@ set(SOLVER_FILES
 # Build the demos
 set(HMMWV_PROGRAMS
     demo_hmmwv
+    demo_hmmwv_varControls
 )
 
 # -----------------------------------------------------

--- a/wheeled_vehicle_models/18dof-gpu/demos/HMMWV/demo_hmmwv.cu
+++ b/wheeled_vehicle_models/18dof-gpu/demos/HMMWV/demo_hmmwv.cu
@@ -18,7 +18,7 @@ int main(int argc, char** argv) {
     // Set the threads per block from command line
     unsigned int threads_per_block = std::stoul(argv[2]);
 
-    std::string file_name = "acc";
+    std::string file_name = "acc3";
     // Driver inputs -> All vehicles have the same driver inputs
     std::string driver_file = "../data/input/" + file_name + ".txt";
 

--- a/wheeled_vehicle_models/18dof-gpu/demos/HMMWV/demo_hmmwv.cu
+++ b/wheeled_vehicle_models/18dof-gpu/demos/HMMWV/demo_hmmwv.cu
@@ -1,0 +1,58 @@
+#include <cuda.h>
+#include <iostream>
+#include <random>
+#include <cuda_runtime.h>
+#include <math.h>
+#include <numeric>
+#include <algorithm>
+#include <iterator>
+
+#include "dof18_halfImplicit_gpu.cuh"
+
+// Use ./executable_name <total_number_of_vehicles> <threads_per_block>
+
+using namespace d18;
+int main(int argc, char** argv) {
+    // Get total number of vehicles from command line
+    unsigned int num_vehicles = std::stoul(argv[1]);
+    // Set the threads per block from command line
+    unsigned int threads_per_block = std::stoul(argv[2]);
+
+    std::string file_name = "acc";
+    // Driver inputs -> All vehicles have the same driver inputs
+    std::string driver_file = "../data/input/" + file_name + ".txt";
+
+    // Vehicle specification -> We assume that all vehicles have the same parameters
+    std::string vehParamsJSON = (char*)"../data/json/HMMWV/vehicle.json";
+    std::string tireParamsJSON = (char*)"../data/json/HMMWV/tmeasy.json";
+
+    // Construct the solver
+    d18SolverHalfImplicitGPU solver(num_vehicles);
+    // The number of vehicles here sets these parameters and inputs for all these vehicles
+    // If there is a need to set different parameters for different vehicles, then the solver
+    // needs to be constructed for each vehicle separately (using the same sovler object)
+    solver.Construct(vehParamsJSON, tireParamsJSON, num_vehicles, driver_file);
+
+    // Set the threads per block
+    solver.SetThreadsPerBlock(threads_per_block);
+
+    // Set the time step of the solver
+    solver.SetTimeStep(1e-3);
+
+    // Now we initialize the states -> These are all set to 0 (struct initializer)
+    VehicleState veh_st;
+    TMeasyState tirelf_st;
+    TMeasyState tirerf_st;
+    TMeasyState tirelr_st;
+    TMeasyState tirerr_st;
+    // Again we initialize the same states for all vehicles
+    solver.Initialize(veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st, num_vehicles);
+
+    // Enable output
+    solver.SetOutput("../data/output/" + file_name + "_hmmwv18", 100, true);
+    // Set the simulation end time -> This is a input that *must* be set by the user
+    solver.SetEndTime(10.0);
+
+    // Solve
+    solver.Solve();
+}

--- a/wheeled_vehicle_models/18dof-gpu/demos/HMMWV/demo_hmmwv_controlsFunctor.cu
+++ b/wheeled_vehicle_models/18dof-gpu/demos/HMMWV/demo_hmmwv_controlsFunctor.cu
@@ -1,0 +1,101 @@
+#include <cuda.h>
+#include <iostream>
+#include <random>
+#include <cuda_runtime.h>
+#include <math.h>
+#include <numeric>
+#include <algorithm>
+#include <iterator>
+#include <chrono>
+
+#include "dof18_halfImplicit_gpu.cuh"
+
+// A simple functor for demonstration
+struct MyFunctor {
+    // It is imperitve that these input outputs need to be maintained
+    __device__ void operator()(double t, DriverInput* controls) {
+        if (t < 1) {
+            controls->m_steering = 0.0;
+            controls->m_throttle = 0.0;
+            controls->m_braking = 0.0;
+        } else {
+            controls->m_steering = 0.0;
+            controls->m_throttle = 0.5;
+            controls->m_braking = 0.0;
+        }
+    }
+};
+
+// Use ./executable_name <total_number_of_vehicles> <threads_per_block>
+
+using namespace d18;
+int main(int argc, char** argv) {
+    // Get total number of vehicles from command line
+    unsigned int num_vehicles = std::stoul(argv[1]);
+    // Set the threads per block from command line
+    unsigned int threads_per_block = std::stoul(argv[2]);
+    std::string file_name = "acc3";
+    // Driver inputs -> All vehicles have the same driver inputs
+    std::string driver_file = "../data/input/" + file_name + ".txt";
+
+    // Vehicle specification -> We assume that all vehicles have the same parameters
+    std::string vehParamsJSON = (char*)"../data/json/HMMWV/vehicle.json";
+    std::string tireParamsJSON = (char*)"../data/json/HMMWV/tmeasy.json";
+
+    // Construct the solver
+    d18SolverHalfImplicitGPU solver(num_vehicles);
+    // The number of vehicles here sets these parameters and inputs for all these vehicles
+    // If there is a need to set different parameters for different vehicles, then the solver
+    // needs to be constructed for each vehicle separately (using the same sovler object)
+    // No driver file
+    solver.Construct(vehParamsJSON, tireParamsJSON, num_vehicles);
+
+    // Set the threads per block
+    solver.SetThreadsPerBlock(threads_per_block);
+
+    // Set the time step of the solver
+    solver.SetTimeStep(1e-3);
+
+    // Decide on the "step" timestep and set it here
+    double control_time_step = 1e-1;
+    solver.SetKernelSimTime(control_time_step);
+
+    // Now we initialize the states -> These are all set to 0 (struct initializer)
+    VehicleState veh_st;
+    TMeasyState tirelf_st;
+    TMeasyState tirerf_st;
+    TMeasyState tirelr_st;
+    TMeasyState tirerr_st;
+    // Again we initialize the same states for all vehicles
+    solver.Initialize(veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st, num_vehicles);
+
+    // NOTE: SolveStep does not support storing output so both of these need to stay commented
+    // solver.SetOutput("../data/output/" + file_name + "_hmmwv18", 100, true);
+    // Enable output for 50 of the vehicles
+    // solver.SetOutput("../data/output/" + file_name + "_hmmwv18step", 100, false, 50);
+
+    // Initialize the controls functor
+    MyFunctor myControlsFunctor;
+    double endTime = 10.0;
+    double timeStep = solver.GetStep();
+    double t = 0;
+    double new_time = 0;
+    // Now solve in loop
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+    cudaEventRecord(start);
+    while (t < (endTime - timeStep / 10.)) {
+        new_time = solver.SolveStep(t, myControlsFunctor);  // Solve for the current time
+        t = new_time;
+    }
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+    float milliseconds = 0;
+    cudaEventElapsedTime(&milliseconds, start, stop);
+    std::cout << "Solve time (ms): " << milliseconds << "\n";
+    // Extract terminal state of choosen vehicles and print the position
+    SimState sim_state_1 = solver.GetSimState(0);
+
+    std::cout << "X Position of vehicle 1: " << sim_state_1._veh_state._x << std::endl;
+}

--- a/wheeled_vehicle_models/18dof-gpu/demos/HMMWV/demo_hmmwv_step.cu
+++ b/wheeled_vehicle_models/18dof-gpu/demos/HMMWV/demo_hmmwv_step.cu
@@ -1,0 +1,97 @@
+#include <cuda.h>
+#include <iostream>
+#include <random>
+#include <cuda_runtime.h>
+#include <math.h>
+#include <numeric>
+#include <algorithm>
+#include <iterator>
+#include <chrono>
+
+#include "dof18_halfImplicit_gpu.cuh"
+
+// Use ./executable_name <total_number_of_vehicles> <threads_per_block>
+
+using namespace d18;
+int main(int argc, char** argv) {
+    // Get total number of vehicles from command line
+    unsigned int num_vehicles = std::stoul(argv[1]);
+    // Set the threads per block from command line
+    unsigned int threads_per_block = std::stoul(argv[2]);
+    std::string file_name = "acc3";
+    // Driver inputs -> All vehicles have the same driver inputs
+    std::string driver_file = "../data/input/" + file_name + ".txt";
+
+    // Vehicle specification -> We assume that all vehicles have the same parameters
+    std::string vehParamsJSON = (char*)"../data/json/HMMWV/vehicle.json";
+    std::string tireParamsJSON = (char*)"../data/json/HMMWV/tmeasy.json";
+
+    // Construct the solver
+    d18SolverHalfImplicitGPU solver(num_vehicles);
+    // The number of vehicles here sets these parameters and inputs for all these vehicles
+    // If there is a need to set different parameters for different vehicles, then the solver
+    // needs to be constructed for each vehicle separately (using the same sovler object)
+    // No driver file
+    solver.Construct(vehParamsJSON, tireParamsJSON, num_vehicles);
+
+    // Set the threads per block
+    solver.SetThreadsPerBlock(threads_per_block);
+
+    // Set the time step of the solver
+    solver.SetTimeStep(1e-3);
+
+    // Decide on the "step" timestep and set it here
+    double control_time_step = 1e-1;
+    solver.SetKernelSimTime(control_time_step);
+
+    // Now we initialize the states -> These are all set to 0 (struct initializer)
+    VehicleState veh_st;
+    TMeasyState tirelf_st;
+    TMeasyState tirerf_st;
+    TMeasyState tirelr_st;
+    TMeasyState tirerr_st;
+    // Again we initialize the same states for all vehicles
+    solver.Initialize(veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st, num_vehicles);
+
+    // NOTE: SolveStep does not support storing output so both of these need to stay commented
+    // solver.SetOutput("../data/output/" + file_name + "_hmmwv18", 100, true);
+    // Enable output for 50 of the vehicles
+    // solver.SetOutput("../data/output/" + file_name + "_hmmwv18step", 100, false, 50);
+
+    double endTime = 10.0;
+    double timeStep = solver.GetStep();
+    double t = 0;
+    double new_time = 0;
+    // Now solve in loop
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+    cudaEventRecord(start);
+    double throttle;
+    double steering;
+    double braking;
+    while (t < (endTime - timeStep / 10.)) {
+        if (t > 1) {
+            throttle = 0.5;
+            steering = 0.0;
+            braking = 0.0;
+        } else {
+            throttle = 0.0;
+            steering = 0.0;
+            braking = 0.0;
+        }
+
+        new_time = solver.SolveStep(t, steering, throttle,
+                                    braking);  // Solve for the current time
+        t = new_time;
+    }
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+    float milliseconds = 0;
+    cudaEventElapsedTime(&milliseconds, start, stop);
+    std::cout << "Solve time (ms): " << milliseconds << "\n";
+    // Extract terminal state of choosen vehicles and print the position
+    SimState sim_state_1 = solver.GetSimState(0);
+
+    std::cout << "X Position of vehicle 1: " << sim_state_1._veh_state._x << std::endl;
+}

--- a/wheeled_vehicle_models/18dof-gpu/demos/HMMWV/demo_hmmwv_varControls.cu
+++ b/wheeled_vehicle_models/18dof-gpu/demos/HMMWV/demo_hmmwv_varControls.cu
@@ -10,18 +10,23 @@
 
 #include "dof18_halfImplicit_gpu.cuh"
 
-// Use ./executable_name <total_number_of_vehicles> <threads_per_block>
+// Use ./executable_name <threads_per_block>
 
 using namespace d18;
 int main(int argc, char** argv) {
-    // Get total number of vehicles from command line
-    unsigned int num_vehicles = std::stoul(argv[1]);
+    // Set the total number of vehicles
+    unsigned int num_vehicles = 1000;
     // Set the threads per block from command line
-    unsigned int threads_per_block = std::stoul(argv[2]);
+    unsigned int threads_per_block = std::stoul(argv[1]);
 
-    std::string file_name = "acc3";
+    // Get two driver files
+    std::string file_name_1 = "acc3";
     // Driver inputs -> All vehicles have the same driver inputs
-    std::string driver_file = "../data/input/" + file_name + ".txt";
+    std::string driver_file_1 = "../data/input/" + file_name_1 + ".txt";
+
+    std::string file_name_2 = "double_lane4";
+    // Driver inputs -> All vehicles have the same driver inputs
+    std::string driver_file_2 = "../data/input/" + file_name_2 + ".txt";
 
     // Vehicle specification -> We assume that all vehicles have the same parameters
     std::string vehParamsJSON = (char*)"../data/json/HMMWV/vehicle.json";
@@ -29,10 +34,11 @@ int main(int argc, char** argv) {
 
     // Construct the solver
     d18SolverHalfImplicitGPU solver(num_vehicles);
-    // The number of vehicles here sets these parameters and inputs for all these vehicles
-    // If there is a need to set different parameters for different vehicles, then the solver
-    // needs to be constructed for each vehicle separately (using the same sovler object)
-    solver.Construct(vehParamsJSON, tireParamsJSON, num_vehicles, driver_file);
+
+    // First construct half the vehicles for driver file 1
+    solver.Construct(vehParamsJSON, tireParamsJSON, 500, driver_file_1);
+    // Then construct the other half for driver file 2
+    solver.Construct(vehParamsJSON, tireParamsJSON, 500, driver_file_2);
 
     // Set the threads per block
     solver.SetThreadsPerBlock(threads_per_block);
@@ -48,13 +54,10 @@ int main(int argc, char** argv) {
     TMeasyState tirerr_st;
     // Again we initialize the same states for all vehicles
     solver.Initialize(veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st, num_vehicles);
-
-    // Enable output for all the vehicles
-    // solver.SetOutput("../data/output/" + file_name + "_hmmwv18", 100, true);
-    // Enable output for 50 of the vehicles
-    solver.SetOutput("../data/output/" + file_name + "_hmmwv18", 100, false, 50);
-    // Set the simulation end time -> This is a input that *must* be set by the user
-    solver.SetEndTime(10.0);
+    // This is the end time of the longer driver file
+    // Note: This means that the last control input is applied till the end of the simulation for the shorter driver
+    // file
+    solver.SetEndTime(22.0);
 
     // Solve
     // Time the solve
@@ -63,4 +66,11 @@ int main(int argc, char** argv) {
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed = end - start;
     std::cout << "Solve time: " << elapsed.count() << " s\n";
+
+    // Extract terminal state of choosen vehicles and print the position
+    SimState sim_state_1 = solver.GetSimState(499);
+    SimState sim_state_2 = solver.GetSimState(999);
+
+    std::cout << "X Position of vehicle 499: " << sim_state_1._veh_state._x << std::endl;
+    std::cout << "X Position of vehicle 999: " << sim_state_2._veh_state._x << std::endl;
 }

--- a/wheeled_vehicle_models/18dof-gpu/dof18_gpu.cu
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_gpu.cu
@@ -483,16 +483,6 @@ __device__ void d18::computeTireRHS(TMeasyState* t_states,
     double f, fos;
     tmxy_combined(&f, &fos, sc, df0, sm, fm, ss, fs);
 
-    // static or "structural" force
-    double Fx, Fy;
-    if (sc > 0.) {
-        Fx = f * sx / sc;
-        Fy = f * sy / sc;
-    } else {
-        Fx = 0.;
-        Fy = 0.;
-    }
-
     // rolling resistance with smoothing
     double vx_min = 0.;
     double vx_max = 0.;
@@ -659,9 +649,6 @@ __device__ void d18::computeTireRHS(TMeasyNrState* t_states,
     Fy = (1.0 - frblend) * Fy0 + frblend * Fy;
 
     // rolling resistance with smoothing -> Below we don't add any smoothing
-    double vx_min = 0.;
-    double vx_max = 0.;
-
     t_states->_My = -t_params->_rr * fz * t_states->_rStat * tanh(t_states->_omega);
 
     // Set the tire forces

--- a/wheeled_vehicle_models/18dof-gpu/dof18_gpu.cu
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_gpu.cu
@@ -1,0 +1,1632 @@
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <stdint.h>
+#include <vector>
+
+#include "dof18_gpu.cuh"
+
+#include "rapidjson/document.h"
+#include "rapidjson/filereadstream.h"
+
+using namespace d18;
+
+// Returns drive torque at a given omega
+__device__ double d18::driveTorque(const VehicleParam* v_params, const double throttle, const double motor_speed) {
+    double motor_torque = 0.;
+    // If we have throttle modulation like in a motor
+    if (v_params->_throttleMod) {
+        MapEntry* powertrain_map = v_params->_powertrainMap;
+
+        size_t len = v_params->_powertrainMapSize;
+        for (size_t i = 0; i < len; i++) {
+            powertrain_map[i]._x = v_params->_powertrainMap[i]._x * throttle;
+            powertrain_map[i]._y = v_params->_powertrainMap[i]._y * throttle;
+        }
+
+        // interpolate in the torque map to get the torque at this paticular
+        // speed
+        motor_torque = getMapY(powertrain_map, motor_speed, v_params->_powertrainMapSize);
+        double motor_losses = getMapY(v_params->_lossesMap, motor_speed, v_params->_lossesMapSize);
+        motor_torque = motor_torque + motor_losses;
+    } else {  // Else we don't multiply the map but just the output torque
+        motor_torque = getMapY(v_params->_powertrainMap, motor_speed, v_params->_powertrainMapSize);
+        double motor_losses = getMapY(v_params->_lossesMap, motor_speed, v_params->_lossesMapSize);
+        motor_torque = motor_torque * throttle + motor_losses;
+    }
+    return motor_torque;
+}
+
+// Function that calculates the torque split to each tire based on the
+// differential max bias Exactly the same as Chrono implementation
+__device__ void d18::differentialSplit(double torque,
+                                       double max_bias,
+                                       double speed_left,
+                                       double speed_right,
+                                       double* torque_left,
+                                       double* torque_right) {
+    double diff = abs(speed_left - speed_right);
+
+    // The bias grows from 1 at diff=0.25 to max_bias at diff=0.5
+    double bias = 1;
+    if (diff > 0.5)
+        bias = max_bias;
+    else if (diff > 0.25)
+        bias = 4 * (max_bias - 1) * diff + (2 - max_bias);
+
+    // Split torque to the slow and fast wheels.
+    double alpha = bias / (1 + bias);
+    double slow = alpha * torque;
+    double fast = torque - slow;
+
+    if (abs(speed_left) < abs(speed_right)) {
+        *torque_left = slow;
+        *torque_right = fast;
+    } else {
+        *torque_left = fast;
+        *torque_right = slow;
+    }
+}
+
+__device__ void d18::vehToTireTransform(TMeasyState* tirelf_st,
+                                        TMeasyState* tirerf_st,
+                                        TMeasyState* tirelr_st,
+                                        TMeasyState* tirerr_st,
+                                        const VehicleState* v_states,
+                                        const double* loads,
+                                        const VehicleParam* v_params,
+                                        double steering) {
+    // Get the steering considering the mapping might be non linear
+    double delta = 0;
+    if (v_params->_nonLinearSteer) {
+        // Extract steer map
+        MapEntry* steer_map = v_params->_steerMap;
+        size_t len = v_params->_steerMapSize;
+        delta = getMapY(steer_map, steering, len);
+    } else {
+        delta = steering * v_params->_maxSteer;
+    }
+
+    // left front
+    tirelf_st->_fz = loads[0];
+    tirelf_st->_vsy = v_states->_v + v_states->_wz * v_params->_a;
+    tirelf_st->_vsx = (v_states->_u - (v_states->_wz * v_params->_cf) / 2.) * cos(delta) + tirelf_st->_vsy * sin(delta);
+
+    // right front
+    tirerf_st->_fz = loads[1];
+    tirerf_st->_vsy = v_states->_v + v_states->_wz * v_params->_a;
+    tirerf_st->_vsx = (v_states->_u + (v_states->_wz * v_params->_cf) / 2.) * cos(delta) + tirerf_st->_vsy * sin(delta);
+
+    // left rear - No steer
+    tirelr_st->_fz = loads[2];
+    tirelr_st->_vsy = v_states->_v - v_states->_wz * v_params->_b;
+    tirelr_st->_vsx = v_states->_u - (v_states->_wz * v_params->_cr) / 2.;
+
+    // rigth rear - No steer
+    tirerr_st->_fz = loads[3];
+    tirerr_st->_vsy = v_states->_v - v_states->_wz * v_params->_b;
+    tirerr_st->_vsx = v_states->_u + (v_states->_wz * v_params->_cr) / 2.;
+}
+
+// Vehicle to tire transform overload for TMeasy tire without relaxation
+__device__ void d18::vehToTireTransform(TMeasyNrState* tirelf_st,
+                                        TMeasyNrState* tirerf_st,
+                                        TMeasyNrState* tirelr_st,
+                                        TMeasyNrState* tirerr_st,
+                                        const VehicleState* v_states,
+                                        const double* loads,
+                                        const VehicleParam* v_params,
+                                        double steering) {
+    // Get the steering considering the mapping might be non linear
+    double delta = 0;
+    if (v_params->_nonLinearSteer) {
+        // Extract steer map
+        MapEntry* steer_map = v_params->_steerMap;
+        size_t len = v_params->_steerMapSize;
+        delta = getMapY(steer_map, steering, len);
+    } else {
+        delta = steering * v_params->_maxSteer;
+    }
+
+    // left front
+    tirelf_st->_fz = loads[0];
+    tirelf_st->_vsy = v_states->_v + v_states->_wz * v_params->_a;
+    tirelf_st->_vsx = (v_states->_u - (v_states->_wz * v_params->_cf) / 2.) * cos(delta) + tirelf_st->_vsy * sin(delta);
+
+    // right front
+    tirerf_st->_fz = loads[1];
+    tirerf_st->_vsy = v_states->_v + v_states->_wz * v_params->_a;
+    tirerf_st->_vsx = (v_states->_u + (v_states->_wz * v_params->_cf) / 2.) * cos(delta) + tirerf_st->_vsy * sin(delta);
+
+    // left rear - No steer
+    tirelr_st->_fz = loads[2];
+    tirelr_st->_vsy = v_states->_v - v_states->_wz * v_params->_b;
+    tirelr_st->_vsx = v_states->_u - (v_states->_wz * v_params->_cr) / 2.;
+
+    // rigth rear - No steer
+    tirerr_st->_fz = loads[3];
+    tirerr_st->_vsy = v_states->_v - v_states->_wz * v_params->_b;
+    tirerr_st->_vsx = v_states->_u + (v_states->_wz * v_params->_cr) / 2.;
+}
+
+__device__ void d18::tireToVehTransform(TMeasyState* tirelf_st,
+                                        TMeasyState* tirerf_st,
+                                        TMeasyState* tirelr_st,
+                                        TMeasyState* tirerr_st,
+                                        const VehicleState* v_states,
+                                        const VehicleParam* v_params,
+                                        double steering) {
+    // Get the steering considering the mapping might be non linear
+    double delta = 0;
+    if (v_params->_nonLinearSteer) {
+        // Extract steer map
+        MapEntry* steer_map = v_params->_steerMap;
+        size_t len = v_params->_steerMapSize;
+        delta = getMapY(steer_map, steering, len);
+    } else {
+        delta = steering * v_params->_maxSteer;
+    }
+
+    double _fx, _fy;
+
+    // left front
+    _fx = tirelf_st->_fx * cos(delta) - tirelf_st->_fy * sin(delta);
+    _fy = tirelf_st->_fx * sin(delta) + tirelf_st->_fy * cos(delta);
+    tirelf_st->_fx = _fx;
+    tirelf_st->_fy = _fy;
+
+    // right front
+    _fx = tirerf_st->_fx * cos(delta) - tirerf_st->_fy * sin(delta);
+    _fy = tirerf_st->_fx * sin(delta) + tirerf_st->_fy * cos(delta);
+    tirerf_st->_fx = _fx;
+    tirerf_st->_fy = _fy;
+
+    // rear tires - No steer so no need to transform
+}
+
+__device__ void d18::tireToVehTransform(TMeasyNrState* tirelf_st,
+                                        TMeasyNrState* tirerf_st,
+                                        TMeasyNrState* tirelr_st,
+                                        TMeasyNrState* tirerr_st,
+                                        const VehicleState* v_states,
+                                        const VehicleParam* v_params,
+                                        double steering) {
+    // Get the steering considering the mapping might be non linear
+    double delta = 0;
+    if (v_params->_nonLinearSteer) {
+        // Extract steer map
+        MapEntry* steer_map = v_params->_steerMap;
+        size_t len = v_params->_steerMapSize;
+        delta = getMapY(steer_map, steering, len);
+    } else {
+        delta = steering * v_params->_maxSteer;
+    }
+
+    double _fx, _fy;
+
+    // left front
+    _fx = tirelf_st->_fx * cos(delta) - tirelf_st->_fy * sin(delta);
+    _fy = tirelf_st->_fx * sin(delta) + tirelf_st->_fy * cos(delta);
+    tirelf_st->_fx = _fx;
+    tirelf_st->_fy = _fy;
+
+    // right front
+    _fx = tirerf_st->_fx * cos(delta) - tirerf_st->_fy * sin(delta);
+    _fy = tirerf_st->_fx * sin(delta) + tirerf_st->_fy * cos(delta);
+    tirerf_st->_fx = _fx;
+    tirerf_st->_fy = _fy;
+
+    // rear tires - No steer so no need to transform
+}
+
+// -----------------------------------------------------------
+/// Tire Functions
+// -----------------------------------------------------------
+
+// Code for the TM easy tire model implemented with the 8DOF model
+__device__ __host__ void d18::tireInit(TMeasyParam* t_params) {
+    // calculates some critical values that are needed
+    t_params->_fzRdynco = (t_params->_pn * (t_params->_rdyncoP2n - 2.0 * t_params->_rdyncoPn + 1.)) /
+                          (2. * (t_params->_rdyncoP2n - t_params->_rdyncoPn));
+
+    t_params->_rdyncoCrit = InterpL(t_params->_fzRdynco, t_params->_rdyncoPn, t_params->_rdyncoP2n, t_params->_pn);
+}
+
+__device__ __host__ void d18::tireInit(TMeasyNrParam* t_params) {
+    // calculates some critical values that are needed
+    t_params->_fzRdynco = (t_params->_pn * (t_params->_rdyncoP2n - 2.0 * t_params->_rdyncoPn + 1.)) /
+                          (2. * (t_params->_rdyncoP2n - t_params->_rdyncoPn));
+
+    t_params->_rdyncoCrit = InterpL(t_params->_fzRdynco, t_params->_rdyncoPn, t_params->_rdyncoP2n, t_params->_pn);
+}
+
+__device__ void
+d18::tmxy_combined(double* f, double* fos, double s, double df0, double sm, double fm, double ss, double fs) {
+    double df0loc = 0.0;
+    if (sm > 0.0) {
+        df0loc = max(2.0 * fm / sm, df0);
+    }
+
+    if (s > 0.0 && df0loc > 0.0) {  // normal operating conditions
+        if (s > ss) {               // full sliding
+            *f = fs;
+            *fos = *f / s;
+        } else {
+            if (s < sm) {  // adhesion
+                double p = df0loc * sm / fm - 2.0;
+                double sn = s / sm;
+                double dn = 1.0 + (sn + p) * sn;
+                *f = df0loc * sm * sn / dn;
+                *fos = df0loc / dn;
+            } else {
+                double a = pow(fm / sm, 2.0) / (df0loc * sm);     // parameter from 2. deriv. of f @ s=sm
+                double sstar = sm + (fm - fs) / (a * (ss - sm));  // connecting point
+                if (sstar <= ss) {                                // 2 parabolas
+                    if (s <= sstar) {
+                        // 1. parabola sm < s < sstar
+                        *f = fm - a * (s - sm) * (s - sm);
+                    } else {
+                        // 2. parabola sstar < s < ss
+                        double b = a * (sstar - sm) / (ss - sstar);
+                        *f = fs + b * (ss - s) * (ss - s);
+                    }
+                } else {
+                    // cubic fallback function
+                    double sn = (s - sm) / (ss - sm);
+                    *f = fm - (fm - fs) * sn * sn * (3.0 - 2.0 * sn);
+                }
+                *fos = *f / s;
+            }
+        }
+    } else {
+        *f = 0.0;
+        *fos = 0.0;
+    }
+}
+
+__device__ void
+d18::computeCombinedColumbForce(double* fx, double* fy, double mu, double vsx, double vsy, double fz, double vcoulomb) {
+    *fx = tanh(-2.0 * vsx / vcoulomb) * fz * mu;
+    *fy = tanh(-2.0 * vsy / vcoulomb) * fz * mu;
+
+    // Nromalize F to the circle
+    if (hypot(*fx, *fy) > fz * mu) {
+        double f = fz * mu / hypot(*fx, *fy);
+        *fx *= f;
+        *fy *= f;
+    }
+}
+
+__device__ void d18::computeTireLoads(double* loads,
+                                      const VehicleState* v_states,
+                                      const VehicleParam* v_params,
+                                      const TMeasyParam* t_params) {
+    double huf = t_params->_r0;
+    double hur = t_params->_r0;
+
+    double Z1 = (v_params->_m * G * v_params->_b) / (2. * (v_params->_a + v_params->_b)) + (v_params->_muf * G) / 2.;
+
+    double Z2 =
+        ((v_params->_muf * huf) / v_params->_cf + v_params->_m * v_params->_b * (v_params->_h - v_params->_hrcf) /
+                                                      (v_params->_cf * (v_params->_a + v_params->_b))) *
+        (v_states->_vdot + v_states->_wz * v_states->_u);
+
+    double Z3 = (v_params->_krof * v_states->_phi + v_params->_brof * v_states->_wx) / v_params->_cf;
+
+    double Z4 = ((v_params->_m * v_params->_h + v_params->_muf * huf + v_params->_mur * hur) *
+                 (v_states->_udot - v_states->_wz * v_states->_v)) /
+                (2. * (v_params->_a + v_params->_b));
+
+    // evaluate the vertical forces for front
+    loads[0] = (Z1 - Z2 - Z3 - Z4) > 0. ? (Z1 - Z2 - Z3 - Z4) : 0.;  // lf
+    loads[1] = (Z1 + Z2 + Z3 - Z4) > 0. ? (Z1 + Z2 + Z3 - Z4) : 0.;  // rf
+
+    Z1 = (v_params->_m * G * v_params->_a) / (2. * (v_params->_a + v_params->_b)) + (v_params->_mur * G) / 2.;
+
+    Z2 = ((v_params->_mur * hur) / v_params->_cr + v_params->_m * v_params->_a * (v_params->_h - v_params->_hrcr) /
+                                                       (v_params->_cr * (v_params->_a + v_params->_b))) *
+         (v_states->_vdot + v_states->_wz * v_states->_u);
+
+    Z3 = (v_params->_kror * v_states->_phi + v_params->_bror * v_states->_wx) / v_params->_cr;
+
+    // evaluate vertical forces for the rear
+    loads[2] = (Z1 - Z2 - Z3 + Z4) > 0. ? (Z1 - Z2 - Z3 + Z4) : 0.;  // lr
+    loads[3] = (Z1 + Z2 + Z3 + Z4) > 0. ? (Z1 + Z2 + Z3 + Z4) : 0.;  // rr
+}
+
+__device__ void d18::computeTireLoads(double* loads,
+                                      const VehicleState* v_states,
+                                      const VehicleParam* v_params,
+                                      const TMeasyNrParam* t_params) {
+    double huf = t_params->_r0;
+    double hur = t_params->_r0;
+
+    double Z1 = (v_params->_m * G * v_params->_b) / (2. * (v_params->_a + v_params->_b)) + (v_params->_muf * G) / 2.;
+
+    double Z2 =
+        ((v_params->_muf * huf) / v_params->_cf + v_params->_m * v_params->_b * (v_params->_h - v_params->_hrcf) /
+                                                      (v_params->_cf * (v_params->_a + v_params->_b))) *
+        (v_states->_vdot + v_states->_wz * v_states->_u);
+
+    double Z3 = (v_params->_krof * v_states->_phi + v_params->_brof * v_states->_wx) / v_params->_cf;
+
+    double Z4 = ((v_params->_m * v_params->_h + v_params->_muf * huf + v_params->_mur * hur) *
+                 (v_states->_udot - v_states->_wz * v_states->_v)) /
+                (2. * (v_params->_a + v_params->_b));
+
+    // evaluate the vertical forces for front
+    loads[0] = (Z1 - Z2 - Z3 - Z4) > 0. ? (Z1 - Z2 - Z3 - Z4) : 0.;  // lf
+    loads[1] = (Z1 + Z2 + Z3 - Z4) > 0. ? (Z1 + Z2 + Z3 - Z4) : 0.;  // rf
+
+    Z1 = (v_params->_m * G * v_params->_a) / (2. * (v_params->_a + v_params->_b)) + (v_params->_mur * G) / 2.;
+
+    Z2 = ((v_params->_mur * hur) / v_params->_cr + v_params->_m * v_params->_a * (v_params->_h - v_params->_hrcr) /
+                                                       (v_params->_cr * (v_params->_a + v_params->_b))) *
+         (v_states->_vdot + v_states->_wz * v_states->_u);
+
+    Z3 = (v_params->_kror * v_states->_phi + v_params->_bror * v_states->_wx) / v_params->_cr;
+
+    // evaluate vertical forces for the rear
+    loads[2] = (Z1 - Z2 - Z3 + Z4) > 0. ? (Z1 - Z2 - Z3 + Z4) : 0.;  // lr
+    loads[3] = (Z1 + Z2 + Z3 + Z4) > 0. ? (Z1 + Z2 + Z3 + Z4) : 0.;  // rr
+}
+
+__device__ void d18::computeTireRHS(TMeasyState* t_states,
+                                    const TMeasyParam* t_params,
+                                    const VehicleParam* v_params,
+                                    double steering) {
+    double delta = 0;
+    if (v_params->_nonLinearSteer) {
+        // Extract steer map
+        MapEntry* steer_map = v_params->_steerMap;
+        size_t len = v_params->_steerMapSize;
+        delta = getMapY(steer_map, steering, len);
+    } else {
+        delta = steering * v_params->_maxSteer;
+    }
+
+    // Get the whichTire based variables out of the way
+    double fz = t_states->_fz;    // vertical force
+    double vsy = t_states->_vsy;  // y slip velocity
+    double vsx = t_states->_vsx;  // x slip velocity
+
+    // If the wheel is off contact, set all states to 0 and return
+    if (fz <= 0) {
+        t_states->_xe = 0;
+        t_states->_ye = 0;
+        t_states->_omega = 0;
+        t_states->_xt = 0;
+        t_states->_rStat = t_params->_r0;
+        t_states->_fx = 0;
+        t_states->_fy = 0;
+        t_states->_My = 0;
+        return;
+    }
+
+    // get our tire deflections so that we can get the loaded radius
+    t_states->_xt = fz / t_params->_kt;
+    t_states->_rStat = t_params->_r0 - t_states->_xt;
+
+    double r_eff;
+    double rdynco;
+    if (fz <= t_params->_fzRdynco) {
+        rdynco = InterpL(fz, t_params->_rdyncoPn, t_params->_rdyncoP2n, t_params->_pn);
+        r_eff = rdynco * t_params->_r0 + (1. - rdynco) * t_states->_rStat;
+    } else {
+        rdynco = t_params->_rdyncoCrit;
+        r_eff = rdynco * t_params->_r0 + (1. - rdynco) * t_states->_rStat;
+    }
+    // with this r_eff, we can finalize the x slip velocity
+    vsx = vsx - (t_states->_omega * r_eff);
+
+    // get the transport velocity - 0.01 here is to prevent singularity
+    double vta = r_eff * abs(t_states->_omega) + 0.01;
+
+    // evaluate the slips
+    double sx = -vsx / vta;
+    double alpha;
+    // only front wheel steering
+    alpha = atan2(vsy, vta) - delta;
+    double sy = -tan(alpha);
+
+    // limit fz
+    if (fz > t_params->_pnmax) {
+        fz = t_params->_pnmax;
+    }
+
+    // calculate all curve parameters through interpolation
+    double dfx0 = InterpQ(fz, t_params->_dfx0Pn, t_params->_dfx0P2n, t_params->_pn);
+    double dfy0 = InterpQ(fz, t_params->_dfy0Pn, t_params->_dfy0P2n, t_params->_pn);
+
+    double fxm = InterpQ(fz, t_params->_fxmPn, t_params->_fxmP2n, t_params->_pn);
+    double fym = InterpQ(fz, t_params->_fymPn, t_params->_fymP2n, t_params->_pn);
+
+    double fxs = InterpQ(fz, t_params->_fxsPn, t_params->_fxsP2n, t_params->_pn);
+    double fys = InterpQ(fz, t_params->_fysPn, t_params->_fysP2n, t_params->_pn);
+
+    double sxm = InterpL(fz, t_params->_sxmPn, t_params->_sxmP2n, t_params->_pn);
+    double sym = InterpL(fz, t_params->_symPn, t_params->_symP2n, t_params->_pn);
+
+    double sxs = InterpL(fz, t_params->_sxsPn, t_params->_sxsP2n, t_params->_pn);
+    double sys = InterpL(fz, t_params->_sysPn, t_params->_sysP2n, t_params->_pn);
+
+    // slip normalizing factors
+    double hsxn = sxm / (sxm + sym) + (fxm / dfx0) / (fxm / dfx0 + fym / dfy0);
+    double hsyn = sym / (sxm + sym) + (fym / dfy0) / (fxm / dfx0 + fym / dfy0);
+
+    // normalized slip
+    double sxn = sx / hsxn;
+    double syn = sy / hsyn;
+
+    // combined slip
+    double sc = hypot(sxn, syn);
+
+    // cos and sine alphs
+    double calpha;
+    double salpha;
+    if (sc > 0) {
+        calpha = sxn / sc;
+        salpha = syn / sc;
+    } else {
+        calpha = sqrt(2.) / 2.;
+        salpha = sqrt(2.) / 2.;
+    }
+
+    // resultant curve parameters in both directions
+    double df0 = hypot(dfx0 * calpha * hsxn, dfy0 * salpha * hsyn);
+    double fm = hypot(fxm * calpha, fym * salpha);
+    double sm = hypot(sxm * calpha / hsxn, sym * salpha / hsyn);
+    double fs = hypot(fxs * calpha, fys * salpha);
+    double ss = hypot(sxs * calpha / hsxn, sys * salpha / hsyn);
+
+    // calculate force and force /slip from the curve characteritics
+    double f, fos;
+    tmxy_combined(&f, &fos, sc, df0, sm, fm, ss, fs);
+
+    // static or "structural" force
+    double Fx, Fy;
+    if (sc > 0.) {
+        Fx = f * sx / sc;
+        Fy = f * sy / sc;
+    } else {
+        Fx = 0.;
+        Fy = 0.;
+    }
+
+    // rolling resistance with smoothing
+    double vx_min = 0.;
+    double vx_max = 0.;
+
+    t_states->_My =
+        -sineStep(vta, vx_min, 0., vx_max, 1.) * t_params->_rr * fz * t_states->_rStat * sgn(t_states->_omega);
+
+    // some normalised slip velocities
+    double vtxs = r_eff * abs(t_states->_omega) * hsxn + 0.01;
+    double vtys = r_eff * abs(t_states->_omega) * hsyn + 0.01;
+
+    // double vtxs = r_eff * abs(t_states->_omega) * hsxn;
+    // double vtys = r_eff * abs(t_states->_omega) * hsyn;
+
+    // Tire velocities for the RHS
+    t_states->_xedot = (-vtxs * t_params->_cx * t_states->_xe - fos * vsx) / (vtxs * t_params->_dx + fos);
+    t_states->_yedot = (-vtys * t_params->_cy * t_states->_ye - fos * (-sy * vta)) / (vtys * t_params->_dy + fos);
+
+    // Also compute the tire forces that need to be applied on the vehicle
+    // Note here that these tire forces are computed using the current pre
+    // integreated xe, unline in the semi-implicit solver
+    double fxdyn = t_params->_dx * (-vtxs * t_params->_cx * t_states->_xe - fos * vsx) / (vtxs * t_params->_dx + fos) +
+                   t_params->_cx * t_states->_xe;
+
+    double fydyn =
+        t_params->_dy * ((-vtys * t_params->_cy * t_states->_ye - fos * (-sy * vta)) / (vtys * t_params->_dy + fos)) +
+        (t_params->_cy * t_states->_ye);
+
+    double fxstr =
+        clamp(t_states->_xe * t_params->_cx + t_states->_xedot * t_params->_dx, -t_params->_fxmP2n, t_params->_fxmP2n);
+    double fystr =
+        clamp(t_states->_ye * t_params->_cy + t_states->_yedot * t_params->_dy, -t_params->_fymP2n, t_params->_fymP2n);
+
+    double weightx = sineStep(abs(vsx), 1., 1., 1.5, 0.);
+    double weighty = sineStep(abs(-sy * vta), 1., 1., 1.5, 0.);
+
+    // now finally get the resultant force
+    t_states->_fx = weightx * fxstr + (1. - weightx) * fxdyn;
+    t_states->_fy = weighty * fystr + (1. - weighty) * fydyn;
+}
+
+__device__ void d18::computeTireRHS(TMeasyNrState* t_states,
+                                    const TMeasyNrParam* t_params,
+                                    const VehicleParam* v_params,
+                                    double steering) {
+    double delta = 0;
+    if (v_params->_nonLinearSteer) {
+        // Extract steer map
+        MapEntry* steer_map = v_params->_steerMap;
+        size_t len = v_params->_steerMapSize;
+        delta = getMapY(steer_map, steering, len);
+    } else {
+        delta = steering * v_params->_maxSteer;
+    }
+
+    // Get the whichTire based variables out of the way
+    double fz = t_states->_fz;    // vertical force
+    double vsy = t_states->_vsy;  // y slip velocity
+    double vsx = t_states->_vsx;  // x slip velocity
+
+    // If the wheel is off contact, set all states to 0 and return
+    if (fz <= 0) {
+        t_states->_omega = 0;
+        t_states->_xt = 0;
+        t_states->_rStat = t_params->_r0;
+        t_states->_fx = 0;
+        t_states->_fy = 0;
+        t_states->_My = 0;
+        return;
+    }
+    // get our tire deflections so that we can get the loaded radius
+    t_states->_xt = fz / t_params->_kt;
+    t_states->_rStat = t_params->_r0 - t_states->_xt;
+
+    // double r_eff = (2 * t_params->_r0 + t_states->_rStat) / 3.;
+    double r_eff;
+    double rdynco;
+    if (fz <= t_params->_fzRdynco) {
+        rdynco = InterpL(fz, t_params->_rdyncoPn, t_params->_rdyncoP2n, t_params->_pn);
+        r_eff = rdynco * t_params->_r0 + (1. - rdynco) * t_states->_rStat;
+    } else {
+        rdynco = t_params->_rdyncoCrit;
+        r_eff = rdynco * t_params->_r0 + (1. - rdynco) * t_states->_rStat;
+    }
+
+    // with this r_eff, we can finalize the x slip velocity
+    vsx = vsx - (t_states->_omega * r_eff);
+
+    // get the transport velocity - 0.01 here is to prevent singularity
+    double vta = r_eff * abs(t_states->_omega) + 0.01;
+
+    // Compute the combined column force (used for low speed stability)
+    double Fx0 = 0;
+    double Fy0 = 0;
+    computeCombinedColumbForce(&Fx0, &Fy0, t_params->_mu, vsx, vsy, fz, t_params->_vcoulomb);
+
+    // evaluate the slips
+    double sx = -vsx / vta;
+    double alpha;
+    // only front wheel steering
+    alpha = atan2(vsy, vta) - delta;
+    double sy = -tan(alpha);
+
+    // limit fz
+    if (fz > t_params->_pnmax) {
+        fz = t_params->_pnmax;
+    }
+
+    // calculate all curve parameters through interpolation
+    double dfx0 = InterpQ(fz, t_params->_dfx0Pn, t_params->_dfx0P2n, t_params->_pn);
+    double dfy0 = InterpQ(fz, t_params->_dfy0Pn, t_params->_dfy0P2n, t_params->_pn);
+
+    double fxm = InterpQ(fz, t_params->_fxmPn, t_params->_fxmP2n, t_params->_pn);
+    double fym = InterpQ(fz, t_params->_fymPn, t_params->_fymP2n, t_params->_pn);
+
+    double fxs = InterpQ(fz, t_params->_fxsPn, t_params->_fxsP2n, t_params->_pn);
+    double fys = InterpQ(fz, t_params->_fysPn, t_params->_fysP2n, t_params->_pn);
+
+    double sxm = InterpL(fz, t_params->_sxmPn, t_params->_sxmP2n, t_params->_pn);
+    double sym = InterpL(fz, t_params->_symPn, t_params->_symP2n, t_params->_pn);
+
+    double sxs = InterpL(fz, t_params->_sxsPn, t_params->_sxsP2n, t_params->_pn);
+    double sys = InterpL(fz, t_params->_sysPn, t_params->_sysP2n, t_params->_pn);
+
+    // Compute the coefficient to "blend" the columb force with the slip force
+    double frblend = sineStep(abs(t_states->_vsx), t_params->_frblend_begin, 0., t_params->_frblend_end, 1.);
+    // Now standard TMeasy tire forces
+    // For now, not using any normalization of the slips - similar to Chrono implementation
+    double sc = hypot(sx, sy);
+    double salpha = 0;
+    double calpha = 0;
+    if (sc > 0) {
+        calpha = sx / sc;
+        salpha = sy / sc;
+    } else {
+        calpha = sqrt(2.) / 2.;
+        salpha = sqrt(2.) / 2.;
+    }
+
+    // resultant curve parameters in both directions
+    double df0 = hypot(dfx0 * calpha, dfy0 * salpha);
+    double fm = t_params->_mu * hypot(fxm * calpha, fym * salpha);
+    double sm = t_params->_mu * hypot(sxm * calpha, sym * salpha);
+    double fs = t_params->_mu * hypot(fxs * calpha, fys * salpha);
+    double ss = t_params->_mu * hypot(sxs * calpha, sys * salpha);
+
+    double f, fos;
+    tmxy_combined(&f, &fos, sc, df0, sm, fm, ss, fs);
+
+    // static or "structural" force
+    double Fx, Fy;
+    if (sc > 0.) {
+        Fx = f * sx / sc;
+        Fy = f * sy / sc;
+    } else {
+        Fx = 0.;
+        Fy = 0.;
+    }
+
+    // Now that we have both the columb force and the slip force, we can combine them with the sine blend to prevent
+    // force jumping
+
+    Fx = (1.0 - frblend) * Fx0 + frblend * Fx;
+    Fy = (1.0 - frblend) * Fy0 + frblend * Fy;
+
+    // rolling resistance with smoothing -> Below we don't add any smoothing
+    double vx_min = 0.;
+    double vx_max = 0.;
+
+    t_states->_My = -t_params->_rr * fz * t_states->_rStat * tanh(t_states->_omega);
+
+    // Set the tire forces
+    t_states->_fx = Fx;
+    t_states->_fy = Fy;
+}
+
+__device__ void d18::computePowertrainRHS(VehicleState* v_states,
+                                          TMeasyState* tirelf_st,
+                                          TMeasyState* tirerf_st,
+                                          TMeasyState* tirelr_st,
+                                          TMeasyState* tirerr_st,
+                                          const VehicleParam* v_params,
+                                          const TMeasyParam* t_params,
+                                          const DriverInput* controls) {
+    // some variables needed outside
+    double torque_t = 0;
+    double max_bias = 2;
+
+    // If we have a torque converter
+    if (v_params->_tcbool) {
+        // set reverse flow to false at each timestep
+        bool tc_reverse_flow = false;
+        // Split the angular velocities all the way uptill the gear box. All
+        // from previous time step
+        double omega_t = 0.25 * (tirelf_st->_omega + tirerf_st->_omega + tirelr_st->_omega + tirerr_st->_omega);
+
+        // get the angular velocity at the torque converter wheel side
+        // Note, the gear includes the differential gear as well
+        double omega_out = omega_t / (v_params->_gearRatios[v_states->_current_gr]);
+
+        // Get the omega input to the torque from the engine from the previous
+        // time step
+        double omega_in = v_states->_crankOmega;
+
+        double sr, cf, tr;
+        size_t cf_size = v_params->_CFmapSize;
+        size_t tr_size = v_params->_TRmapSize;
+
+        if ((omega_out < 1e-9) || (omega_in < 1e-9)) {  // if we are at the start things can get unstable
+            sr = 0;
+            // Get capacity factor from capacity lookup table
+            cf = getMapY(v_params->_CFmap, sr, cf_size);
+
+            // Get torque ratio from Torque ratio lookup table
+            tr = getMapY(v_params->_TRmap, sr, tr_size);
+        } else {
+            // speed ratio for torque converter
+            sr = omega_out / omega_in;
+
+            // Check reverse flow
+            if (sr > 1.) {
+                sr = 1. - (sr - 1.);
+                tc_reverse_flow = true;
+            }
+
+            if (sr < 0) {
+                sr = 0;
+            }
+
+            // get capacity factor from lookup table
+            cf = getMapY(v_params->_CFmap, sr, cf_size);
+
+            // Get torque ratio from Torque ratio lookup table
+            tr = getMapY(v_params->_TRmap, sr, tr_size);
+        }
+        // torque applied to the crank shaft
+        double torque_in = -pow((omega_in / cf), 2);
+
+        // if its reverse flow, this should act as a brake
+        if (tc_reverse_flow) {
+            torque_in = -torque_in;
+        }
+
+        // torque applied to the shaft from torque converter on the wheel side
+        double torque_out;
+        if (tc_reverse_flow) {
+            torque_out = -torque_in;
+        } else {
+            torque_out = -tr * torque_in;
+        }
+
+        // Now torque after the transimission
+        torque_t = torque_out / v_params->_gearRatios[v_states->_current_gr];
+        if (abs((v_states->_u - 0) < 1e-9) && (torque_t < 0)) {
+            torque_t = 0;
+        }
+
+        //////// Integrate Crank shaft
+        v_states->_dOmega_crank = (1. / v_params->_crankInertia) *
+                                  (driveTorque(v_params, controls->m_throttle, v_states->_crankOmega) + torque_in);
+
+        ////// Gear shift for the next time step -> Here we have to check the
+        /// RPM of
+        /// the shaft from the T.C
+        if (omega_out > v_params->_shiftMap[v_states->_current_gr]._y) {
+            // check if we have enough gears to upshift
+            if (v_states->_current_gr < v_params->_noGears - 1) {
+                v_states->_current_gr++;
+            }
+        }
+        // downshift
+        else if (omega_out < v_params->_shiftMap[v_states->_current_gr]._x) {
+            // check if we can down shift
+            if (v_states->_current_gr > 0) {
+                v_states->_current_gr--;
+            }
+        }
+    } else {  // If there is no torque converter, then the crank shaft does not
+              // have a state so we directly updated the crankOmega to be used
+        v_states->_crankOmega = 0.25 * (tirelf_st->_omega + tirerf_st->_omega + tirelr_st->_omega + tirerr_st->_omega) /
+                                v_params->_gearRatios[v_states->_current_gr];
+
+        // The torque after tranny will then just become as there is no torque
+        // converter
+        torque_t = driveTorque(v_params, controls->m_throttle, v_states->_crankOmega) /
+                   v_params->_gearRatios[v_states->_current_gr];
+
+        if (abs((v_states->_u - 0) < 1e-9) && (torque_t < 0)) {
+            torque_t = 0;
+        }
+
+        ///// Upshift gear for next time step -> Here the crank shaft is
+        /// directly
+        /// connected to the gear box
+        if (v_states->_crankOmega > v_params->_shiftMap[v_states->_current_gr]._y) {
+            // check if we have enough gears to upshift
+            if (v_states->_current_gr < v_params->_noGears - 1) {
+                v_states->_current_gr++;
+            }
+        }
+        // downshift
+        else if (v_states->_crankOmega < v_params->_shiftMap[v_states->_current_gr]._x) {
+            // check if we can down shift
+            if (v_states->_current_gr > 0) {
+                v_states->_current_gr--;
+            }
+        }
+    }
+
+    //////// Amount of torque transmitted to the wheels
+
+    // torque split between the  front and rear (always half)
+    double torque_front = 0;
+    double torque_rear = 0;
+    if (v_params->_driveType) {  // If we have a 4WD vehicle split torque equally
+        torque_front = torque_t * 0.5;
+        torque_rear = torque_t * 0.5;
+    } else {
+        if (v_params->_whichWheels) {
+            torque_front = 0;
+            torque_rear = torque_t;
+        } else {
+            torque_front = torque_t;
+            torque_rear = 0;
+        }
+    }
+
+    // first the front wheels
+    differentialSplit(torque_front, max_bias, tirelf_st->_omega, tirerf_st->_omega, &tirelf_st->_engTor,
+                      &tirerf_st->_engTor);
+    // then rear wheels
+    differentialSplit(torque_rear, max_bias, tirelr_st->_omega, tirerr_st->_omega, &tirelr_st->_engTor,
+                      &tirerr_st->_engTor);
+
+    // now use this force for our omegas
+    // Get dOmega for each tire
+    tirelf_st->_dOmega = (1 / t_params->_jw) * (tirelf_st->_engTor + tirelf_st->_My -
+                                                sgn(tirelf_st->_omega) * brakeTorque(v_params, controls->m_braking) -
+                                                tirelf_st->_fx * tirelf_st->_rStat);
+
+    tirerf_st->_dOmega = (1 / t_params->_jw) * (tirerf_st->_engTor + tirerf_st->_My -
+                                                sgn(tirerf_st->_omega) * brakeTorque(v_params, controls->m_braking) -
+                                                tirerf_st->_fx * tirerf_st->_rStat);
+
+    tirelr_st->_dOmega = (1 / t_params->_jw) * (tirelr_st->_engTor + tirelr_st->_My -
+                                                sgn(tirelr_st->_omega) * brakeTorque(v_params, controls->m_braking) -
+                                                tirelr_st->_fx * tirelr_st->_rStat);
+
+    tirerr_st->_dOmega = (1 / t_params->_jw) * (tirerr_st->_engTor + tirerr_st->_My -
+                                                sgn(tirerr_st->_omega) * brakeTorque(v_params, controls->m_braking) -
+                                                tirerr_st->_fx * tirerr_st->_rStat);
+}
+
+__device__ void d18::computePowertrainRHS(VehicleState* v_states,
+                                          TMeasyNrState* tirelf_st,
+                                          TMeasyNrState* tirerf_st,
+                                          TMeasyNrState* tirelr_st,
+                                          TMeasyNrState* tirerr_st,
+                                          const VehicleParam* v_params,
+                                          const TMeasyNrParam* t_params,
+                                          const DriverInput* controls) {
+    // some variables needed outside
+    double torque_t = 0;
+    double max_bias = 2;
+
+    // If we have a torque converter
+    if (v_params->_tcbool) {
+        // set reverse flow to false at each timestep
+        bool tc_reverse_flow = false;
+        // Split the angular velocities all the way uptill the gear box. All
+        // from previous time step
+        double omega_t = 0.25 * (tirelf_st->_omega + tirerf_st->_omega + tirelr_st->_omega + tirerr_st->_omega);
+
+        // get the angular velocity at the torque converter wheel side
+        // Note, the gear includes the differential gear as well
+        double omega_out = omega_t / (v_params->_gearRatios[v_states->_current_gr]);
+
+        // Get the omega input to the torque from the engine from the previous
+        // time step
+        double omega_in = v_states->_crankOmega;
+
+        double sr, cf, tr;
+        size_t cf_size = v_params->_CFmapSize;
+        size_t tr_size = v_params->_TRmapSize;
+        if ((omega_out < 1e-9) || (omega_in < 1e-9)) {  // if we are at the start things can get unstable
+            sr = 0;
+            // Get capacity factor from capacity lookup table
+            cf = getMapY(v_params->_CFmap, sr, cf_size);
+
+            // Get torque ratio from Torque ratio lookup table
+            tr = getMapY(v_params->_TRmap, sr, tr_size);
+        } else {
+            // speed ratio for torque converter
+            sr = omega_out / omega_in;
+
+            // Check reverse flow
+            if (sr > 1.) {
+                sr = 1. - (sr - 1.);
+                tc_reverse_flow = true;
+            }
+
+            if (sr < 0) {
+                sr = 0;
+            }
+
+            // get capacity factor from lookup table
+            cf = getMapY(v_params->_CFmap, sr, cf_size);
+
+            // Get torque ratio from Torque ratio lookup table
+            tr = getMapY(v_params->_TRmap, sr, tr_size);
+        }
+        // torque applied to the crank shaft
+        double torque_in = -pow((omega_in / cf), 2);
+
+        // if its reverse flow, this should act as a brake
+        if (tc_reverse_flow) {
+            torque_in = -torque_in;
+        }
+
+        // torque applied to the shaft from torque converter on the wheel side
+        double torque_out;
+        if (tc_reverse_flow) {
+            torque_out = -torque_in;
+        } else {
+            torque_out = -tr * torque_in;
+        }
+
+        // Now torque after the transimission
+        torque_t = torque_out / v_params->_gearRatios[v_states->_current_gr];
+        if (abs((v_states->_u - 0) < 1e-9) && (torque_t < 0)) {
+            torque_t = 0;
+        }
+
+        //////// Integrate Crank shaft
+        v_states->_dOmega_crank = (1. / v_params->_crankInertia) *
+                                  (driveTorque(v_params, controls->m_throttle, v_states->_crankOmega) + torque_in);
+
+        ////// Gear shift for the next time step -> Here we have to check the
+        /// RPM of
+        /// the shaft from the T.C
+        if (omega_out > v_params->_shiftMap[v_states->_current_gr]._y) {
+            // check if we have enough gears to upshift
+            if (v_states->_current_gr < v_params->_noGears - 1) {
+                v_states->_current_gr++;
+            }
+        }
+        // downshift
+        else if (omega_out < v_params->_shiftMap[v_states->_current_gr]._x) {
+            // check if we can down shift
+            if (v_states->_current_gr > 0) {
+                v_states->_current_gr--;
+            }
+        }
+    } else {  // If there is no torque converter, then the crank shaft does not
+              // have a state so we directly updated the crankOmega to be used
+        v_states->_crankOmega = 0.25 * (tirelf_st->_omega + tirerf_st->_omega + tirelr_st->_omega + tirerr_st->_omega) /
+                                v_params->_gearRatios[v_states->_current_gr];
+
+        // The torque after tranny will then just become as there is no torque
+        // converter
+        torque_t = driveTorque(v_params, controls->m_throttle, v_states->_crankOmega) /
+                   v_params->_gearRatios[v_states->_current_gr];
+
+        if (abs((v_states->_u - 0) < 1e-9) && (torque_t < 0)) {
+            torque_t = 0;
+        }
+
+        ///// Upshift gear for next time step -> Here the crank shaft is
+        /// directly
+        /// connected to the gear box
+        if (v_states->_crankOmega > v_params->_shiftMap[v_states->_current_gr]._y) {
+            // check if we have enough gears to upshift
+            if (v_states->_current_gr < v_params->_noGears - 1) {
+                v_states->_current_gr++;
+            }
+        }
+        // downshift
+        else if (v_states->_crankOmega < v_params->_shiftMap[v_states->_current_gr]._x) {
+            // check if we can down shift
+            if (v_states->_current_gr > 0) {
+                v_states->_current_gr--;
+            }
+        }
+    }
+
+    //////// Amount of torque transmitted to the wheels
+
+    // torque split between the  front and rear (always half)
+    double torque_front = 0;
+    double torque_rear = 0;
+    if (v_params->_driveType) {  // If we have a 4WD vehicle split torque equally
+        torque_front = torque_t * 0.5;
+        torque_rear = torque_t * 0.5;
+    } else {
+        if (v_params->_whichWheels) {
+            torque_front = 0;
+            torque_rear = torque_t;
+        } else {
+            torque_front = torque_t;
+            torque_rear = 0;
+        }
+    }
+
+    // first the front wheels
+    differentialSplit(torque_front, max_bias, tirelf_st->_omega, tirerf_st->_omega, &tirelf_st->_engTor,
+                      &tirerf_st->_engTor);
+    // then rear wheels
+    differentialSplit(torque_rear, max_bias, tirelr_st->_omega, tirerr_st->_omega, &tirelr_st->_engTor,
+                      &tirerr_st->_engTor);
+
+    // now use this force for our omegas
+    // Get dOmega for each tire
+    tirelf_st->_dOmega = (1 / t_params->_jw) * (tirelf_st->_engTor + tirelf_st->_My -
+                                                sgn(tirelf_st->_omega) * brakeTorque(v_params, controls->m_braking) -
+                                                tirelf_st->_fx * tirelf_st->_rStat);
+
+    tirerf_st->_dOmega = (1 / t_params->_jw) * (tirerf_st->_engTor + tirerf_st->_My -
+                                                sgn(tirerf_st->_omega) * brakeTorque(v_params, controls->m_braking) -
+                                                tirerf_st->_fx * tirerf_st->_rStat);
+
+    tirelr_st->_dOmega = (1 / t_params->_jw) * (tirelr_st->_engTor + tirelr_st->_My -
+                                                sgn(tirelr_st->_omega) * brakeTorque(v_params, controls->m_braking) -
+                                                tirelr_st->_fx * tirelr_st->_rStat);
+
+    tirerr_st->_dOmega = (1 / t_params->_jw) * (tirerr_st->_engTor + tirerr_st->_My -
+                                                sgn(tirerr_st->_omega) * brakeTorque(v_params, controls->m_braking) -
+                                                tirerr_st->_fx * tirerr_st->_rStat);
+}
+
+__device__ void d18::computeVehRHS(VehicleState* v_states,
+                                   const VehicleParam* v_params,
+                                   const double* fx,
+                                   const double* fy) {
+    // get the total mass of the vehicle and the vertical distance from the
+    // sprung mass C.M. to the vehicle
+    double mt = v_params->_m + 2 * (v_params->_muf + v_params->_mur);
+    double hrc = (v_params->_hrcf * v_params->_b + v_params->_hrcr * v_params->_a) / (v_params->_a + v_params->_b);
+
+    // a bunch of variables to simplify the formula
+    double E1 = -mt * v_states->_wz * v_states->_u + (fy[0] + fy[1] + fy[2] + fy[3]);
+
+    double E2 = (fy[0] + fy[1]) * v_params->_a - (fy[2] + fy[3]) * v_params->_b + (fx[1] - fx[0]) * v_params->_cf / 2 +
+                (fx[3] - fx[2]) * v_params->_cr / 2 +
+                (-v_params->_muf * v_params->_a + v_params->_mur * v_params->_b) * v_states->_wz * v_states->_u;
+
+    double E3 = v_params->_m * G * hrc * v_states->_phi - (v_params->_krof + v_params->_kror) * v_states->_phi -
+                (v_params->_brof + v_params->_bror) * v_states->_wx + hrc * v_params->_m * v_states->_wz * v_states->_u;
+
+    double A1 = v_params->_mur * v_params->_b - v_params->_muf * v_params->_a;
+
+    double A2 = v_params->_jx + v_params->_m * pow(hrc, 2);
+
+    double A3 = hrc * v_params->_m;
+
+    // Integration using half implicit - level 2 variables found first in next
+    // time step
+
+    // update the acceleration states - level 2 variables
+
+    v_states->_udot =
+        v_states->_wz * v_states->_v +
+        (1 / mt) * ((fx[0] + fx[1] + fx[2] + fx[3]) +
+                    (-v_params->_mur * v_params->_b + v_params->_muf * v_params->_a) * pow(v_states->_wz, 2) -
+                    2. * hrc * v_params->_m * v_states->_wz * v_states->_wx);
+
+    // common denominator
+    double denom = (A2 * pow(A1, 2) - 2. * A1 * A3 * v_params->_jxz + v_params->_jz * pow(A3, 2) +
+                    mt * pow(v_params->_jxz, 2) - A2 * v_params->_jz * mt);
+
+    v_states->_vdot = (E1 * pow(v_params->_jxz, 2) - A1 * A2 * E2 + A1 * E3 * v_params->_jxz +
+                       A3 * E2 * v_params->_jxz - A2 * E1 * v_params->_jz - A3 * E3 * v_params->_jz) /
+                      denom;
+
+    v_states->_wxdot = (pow(A1, 2) * E3 - A1 * A3 * E2 + A1 * E1 * v_params->_jxz - A3 * E1 * v_params->_jz +
+                        E2 * v_params->_jxz * mt - E3 * v_params->_jz * mt) /
+                       denom;
+
+    v_states->_wzdot = (pow(A3, 2) * E2 - A1 * A2 * E1 - A1 * A3 * E3 + A3 * E1 * v_params->_jxz - A2 * E2 * mt +
+                        E3 * v_params->_jxz * mt) /
+                       denom;
+
+    // update the level 0 varaibles using the next time step level 1 varibales
+    // over here still using the old psi and phi.. should we update psi and phi
+    // first and then use those????
+
+    v_states->_dx = (v_states->_u * cos(v_states->_psi) - v_states->_v * sin(v_states->_psi));
+
+    v_states->_dy = (v_states->_u * sin(v_states->_psi) + v_states->_v * cos(v_states->_psi));
+}
+
+// ---------------------------------------------------------
+// Setting the tire and vehicle parameters from the JSON file
+// ---------------------------------------------------------
+
+// setting Vehicle parameters using a JSON file
+__host__ void d18::setVehParamsJSON(VehicleParam& v_params, const char* fileName) {
+    // Open the file
+    FILE* fp = fopen(fileName, "r");
+
+    char readBuffer[65536];
+    rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
+
+    // parse the stream into DOM tree
+    rapidjson::Document d;
+    d.ParseStream(is);
+    fclose(fp);
+
+    if (d.HasParseError()) {
+        std::cout << "Error with rapidjson:" << std::endl << d.GetParseError() << std::endl;
+    }
+
+    // the file should have all these parameters defined
+    v_params._a = d["a"].GetDouble();
+    v_params._b = d["b"].GetDouble();
+    v_params._m = d["m"].GetDouble();
+    v_params._h = d["h"].GetDouble();
+    v_params._jz = d["jz"].GetDouble();
+    v_params._jx = d["jx"].GetDouble();
+    v_params._jxz = d["jxz"].GetDouble();
+    v_params._cf = d["cf"].GetDouble();
+    v_params._cr = d["cr"].GetDouble();
+    v_params._muf = d["muf"].GetDouble();
+    v_params._mur = d["mur"].GetDouble();
+    v_params._hrcf = d["hrcf"].GetDouble();
+    v_params._hrcr = d["hrcr"].GetDouble();
+    v_params._krof = d["krof"].GetDouble();
+    v_params._kror = d["kror"].GetDouble();
+    v_params._brof = d["brof"].GetDouble();
+    v_params._bror = d["bror"].GetDouble();
+
+    // Non linear steering which maps the normalized steering input to wheel
+    // angle
+    v_params._nonLinearSteer = d["nonLinearSteer"].GetBool();
+    if (v_params._nonLinearSteer) {
+        size_t steerMapSize = d["steerMap"].Size();
+        CHECK_CUDA_ERROR(cudaMallocManaged((void**)&v_params._steerMap, sizeof(MapEntry) * steerMapSize));
+        for (unsigned int i = 0; i < steerMapSize; i++) {
+            MapEntry m;
+            m._x = d["steerMap"][i][0u].GetDouble();
+            m._y = d["steerMap"][i][1u].GetDouble();
+            v_params._steerMap[i] = m;
+        }
+        v_params._steerMapSize = steerMapSize;
+    }
+    // If there is no non linear steer then the normalized steering input is
+    // just multiplied by the max steering wheel angle
+    else {
+        v_params._maxSteer = d["maxSteer"].GetDouble();
+    }
+
+    v_params._maxSteer = d["maxSteer"].GetDouble();
+
+    // read the gear ratios
+    size_t noGears = d["gearRatios"].Size();
+    CHECK_CUDA_ERROR(
+        cudaMallocManaged((void**)&v_params._gearRatios, sizeof(double) * noGears));  // assign the memory for the gears
+    for (unsigned int i = 0; i < noGears; i++) {
+        v_params._gearRatios[i] = d["gearRatios"][i].GetDouble();
+    }
+    v_params._noGears = noGears;
+
+    // Check if we have upshiftRPM and downshiftRPM set
+    CHECK_CUDA_ERROR(cudaMallocManaged((void**)&v_params._shiftMap, sizeof(MapEntry) * noGears));
+    if (d.HasMember("upshiftRPM") && d.HasMember("downshiftRPM")) {
+        // If this is the case then just set the shift map for all gears to the
+        // same value
+        for (unsigned int i = 0; i < noGears; i++) {
+            MapEntry m;
+            m._x = d["downshiftRPM"].GetDouble() * rpm2rad;
+            m._y = d["upshiftRPM"].GetDouble() * rpm2rad;
+            v_params._shiftMap[i] = m;
+        }
+    } else {
+        // If there is no upshiftRPM and downshiftRPM then there should be a
+        // shift map and this should have as many entries as the number of gears
+        for (unsigned int i = 0; i < noGears; i++) {
+            MapEntry m;
+            m._x = d["shiftMap"][i][0u].GetDouble() * rpm2rad;  // downshift
+            m._y = d["shiftMap"][i][1u].GetDouble() * rpm2rad;  // upshift
+            v_params._shiftMap[i] = m;
+        }
+    }
+
+    v_params._tcbool = d["tcBool"].GetBool();
+
+    v_params._maxBrakeTorque = d["maxBrakeTorque"].GetDouble();
+
+    v_params._throttleMod = d["throttleMod"].GetBool();
+    // Read the powertrain map
+    size_t powertrainMapSize = d["torqueMap"].Size();
+    CHECK_CUDA_ERROR(cudaMallocManaged((void**)&v_params._powertrainMap, sizeof(MapEntry) * powertrainMapSize));
+    for (unsigned int i = 0; i < powertrainMapSize; i++) {
+        MapEntry m;
+        m._x = d["torqueMap"][i][0u].GetDouble() * rpm2rad;
+        m._y = d["torqueMap"][i][1u].GetDouble();
+        v_params._powertrainMap[i] = m;
+    }
+    v_params._powertrainMapSize = powertrainMapSize;
+
+    // Read the losses map
+    size_t lossesMapSize = d["lossesMap"].Size();
+    CHECK_CUDA_ERROR(cudaMallocManaged((void**)&v_params._lossesMap, sizeof(MapEntry) * lossesMapSize));
+    for (unsigned int i = 0; i < lossesMapSize; i++) {
+        MapEntry m;
+        m._x = d["lossesMap"][i][0u].GetDouble() * rpm2rad;
+        m._y = d["lossesMap"][i][1u].GetDouble();
+        v_params._lossesMap[i] = m;
+    }
+    v_params._lossesMapSize = lossesMapSize;
+
+    // if we have a torque converter, we need this data
+    if (v_params._tcbool) {
+        v_params._crankInertia = d["crankInertia"].GetDouble();
+        size_t CFmapSize = d["capacityFactorMap"].Size();
+        CHECK_CUDA_ERROR(cudaMallocManaged((void**)&v_params._CFmap, sizeof(MapEntry) * CFmapSize));
+        for (unsigned int i = 0; i < CFmapSize; i++) {
+            MapEntry m;
+            m._x = d["capacityFactorMap"][i][0u].GetDouble();
+            m._y = d["capacityFactorMap"][i][1u].GetDouble();
+            v_params._CFmap[i] = m;
+        }
+        v_params._CFmapSize = CFmapSize;
+
+        unsigned int TRmapSize = d["torqueRatioMap"].Size();
+        CHECK_CUDA_ERROR(cudaMallocManaged((void**)&v_params._TRmap, sizeof(MapEntry) * TRmapSize));
+        for (unsigned int i = 0; i < TRmapSize; i++) {
+            MapEntry m;
+            m._x = d["torqueRatioMap"][i][0u].GetDouble();
+            m._y = d["torqueRatioMap"][i][1u].GetDouble();
+            v_params._TRmap[i] = m;
+        }
+        v_params._TRmapSize = TRmapSize;
+    }
+
+    // Store the drive Type (1 is 4WD and 0 is 2WD (rear wheels))
+    if (d.HasMember("4wd")) {
+        v_params._driveType = d["4wd"].GetBool();
+        v_params._whichWheels = d["rearWheels"].GetBool();  // 1 for rear wheels 0 for front wheels
+    }
+}
+
+// setting Tire parameters using a JSON file
+__host__ void d18::setTireParamsJSON(TMeasyParam& t_params, const char* fileName) {
+    // Open the file
+    FILE* fp = fopen(fileName, "r");
+
+    char readBuffer[32768];
+    rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
+
+    // parse the stream into DOM tree
+    rapidjson::Document d;
+    d.ParseStream(is);
+    fclose(fp);
+
+    if (d.HasParseError()) {
+        std::cout << "Error with rapidjson:" << std::endl << d.GetParseError() << std::endl;
+    }
+
+    // pray to what ever you believe in and hope that the json file has all
+    // these
+    t_params._jw = d["jw"].GetDouble();
+    t_params._rr = d["rr"].GetDouble();
+    t_params._r0 = d["r0"].GetDouble();
+    t_params._pn = d["pn"].GetDouble();
+    t_params._pnmax = d["pnmax"].GetDouble();
+    t_params._cx = d["cx"].GetDouble();
+    t_params._cy = d["cy"].GetDouble();
+    t_params._kt = d["kt"].GetDouble();
+    t_params._dx = d["dx"].GetDouble();
+    t_params._dy = d["dy"].GetDouble();
+    t_params._rdyncoPn = d["rdyncoPn"].GetDouble();
+    t_params._rdyncoP2n = d["rdyncoP2n"].GetDouble();
+    t_params._fzRdynco = d["fzRdynco"].GetDouble();
+    t_params._rdyncoCrit = d["rdyncoCrit"].GetDouble();
+
+    t_params._dfx0Pn = d["dfx0Pn"].GetDouble();
+    t_params._dfx0P2n = d["dfx0P2n"].GetDouble();
+    t_params._fxmPn = d["fxmPn"].GetDouble();
+    t_params._fxmP2n = d["fxmP2n"].GetDouble();
+    t_params._fxsPn = d["fxsPn"].GetDouble();
+    t_params._fxsP2n = d["fxsP2n"].GetDouble();
+    t_params._sxmPn = d["sxmPn"].GetDouble();
+    t_params._sxmP2n = d["sxmP2n"].GetDouble();
+    t_params._sxsPn = d["sxsPn"].GetDouble();
+    t_params._sxsP2n = d["sxsP2n"].GetDouble();
+
+    t_params._dfy0Pn = d["dfy0Pn"].GetDouble();
+    t_params._dfy0P2n = d["dfy0P2n"].GetDouble();
+    t_params._fymPn = d["fymPn"].GetDouble();
+    t_params._fymP2n = d["fymP2n"].GetDouble();
+    t_params._fysPn = d["fysPn"].GetDouble();
+    t_params._fysP2n = d["fysP2n"].GetDouble();
+    t_params._symPn = d["symPn"].GetDouble();
+    t_params._symP2n = d["symP2n"].GetDouble();
+    t_params._sysPn = d["sysPn"].GetDouble();
+    t_params._sysP2n = d["sysP2n"].GetDouble();
+}
+
+// setting Tire parameters using a JSON file for a TMeasyNr
+__host__ void d18::setTireParamsJSON(TMeasyNrParam& t_params, const char* fileName) {
+    // Open the file
+    FILE* fp = fopen(fileName, "r");
+
+    char readBuffer[32768];
+    rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
+
+    // parse the stream into DOM tree
+    rapidjson::Document d;
+    d.ParseStream(is);
+    fclose(fp);
+
+    if (d.HasParseError()) {
+        std::cout << "Error with rapidjson:" << std::endl << d.GetParseError() << std::endl;
+    }
+
+    // First check if the user wants to specify high-level tire parameters or low level
+    // Check if there is a member called "highLevelParams", if it does not exist, then we assume the user specifies low
+    // level parameters
+    if (d.HasMember("highLevelParams")) {
+        if (d["highLevelParams"].GetBool()) {
+            // Set basic desing parameters
+            t_params._jw = d["jw"].GetDouble();
+            t_params._rr = d["rr"].GetDouble();
+            t_params._mu = d["mu"].GetDouble();
+            t_params._r0 = d["r0"].GetDouble();
+            t_params._rdyncoPn = d["rdyncoPn"].GetDouble();
+            t_params._rdyncoP2n = d["rdyncoP2n"].GetDouble();
+            t_params._fzRdynco = d["fzRdynco"].GetDouble();
+            t_params._rdyncoCrit = d["rdyncoCrit"].GetDouble();
+
+            // Some very specific parameters that the user might not want to define, set to default otherwise
+            if (d.HasMember("vCoulomb")) {
+                t_params._vcoulomb = d["vCoulomb"].GetDouble();
+            } else {
+                t_params._vcoulomb = 1.0;
+            }
+            if (d.HasMember("frblendBegin")) {
+                t_params._frblend_begin = d["frblendBegin"].GetDouble();
+            } else {
+                t_params._frblend_begin = 1.0;
+            }
+            if (d.HasMember("frblendEnd")) {
+                t_params._frblend_end = d["frblendEnd"].GetDouble();
+            } else {
+                t_params._frblend_end = 3.0;
+            }
+
+            // Get the high level parameters from the JSON file
+            double width = d["width"].GetDouble();
+            double rimRadius = d["rimRadius"].GetDouble();
+            double p_li = 1.0;   // Inflation pressure at load index [Pa]
+            double p_use = 1.0;  // Inflation pressure at use time [Pa]
+            // Tire can either be specified with load index or bearing capacity
+            if (d.HasMember("loadIndex")) {
+                // Information about tire inflation pressure might be present if the user wants to use the inflation
+                if (d.HasMember("inflationPressureDesign")) {
+                    p_li = d["inflationPressureDesign"].GetDouble();
+                } else {
+                    p_li = 0.0;
+                }
+                if (d.HasMember("inflationPressureUse")) {
+                    p_use = d["inflationPressureUse"].GetDouble();
+                } else {
+                    p_use = 0.0;
+                }
+                if (p_use > 0.0 && p_li > 0.0) {
+                    ////pressure_info_found = true;
+                } else {
+                    p_li = p_use = 1.0;
+                }
+
+                unsigned int li = d["loadIndex"].GetUint();
+                t_params._li = li;  // Just setting this although its not used anywhere for now
+                t_params._p_li = p_li;
+                t_params._p_use = p_use;
+                std::string vehicle_type = d["vehicleType"].GetString();
+                if (vehicle_type.compare("Truck") == 0) {
+                    GuessTruck80Par(li, width, (t_params._r0 - rimRadius) / width, 2 * rimRadius, p_li, p_use,
+                                    t_params);
+                } else {
+                    GuessPassCar70Par(li, width, (t_params._r0 - rimRadius) / width, 2 * rimRadius, p_li, p_use,
+                                      t_params);
+                }
+            } else {  // if it does not have load index, it has to have maximum bearing capacity
+                      // Information about tire inflation pressure might be present if the user wants to use the
+                      // inflation
+                if (d.HasMember("inflationPressureDesign")) {
+                    p_li = d["inflationPressureDesign"].GetDouble();
+                } else {
+                    p_li = 0.0;
+                }
+                if (d.HasMember("inflationPressureUse")) {
+                    p_use = d["inflationPressureUse"].GetDouble();
+                } else {
+                    p_use = 0.0;
+                }
+                if (p_use > 0.0 && p_li > 0.0) {
+                    ////pressure_info_found = true;
+                } else {
+                    p_li = p_use = 1.0;
+                }
+                t_params._p_li = p_li;
+                t_params._p_use = p_use;
+                double bearing_capacity = d["maximumBearingCapacity"].GetDouble();
+                t_params._bearingCapacity =
+                    bearing_capacity;  // Just setting this so that it can be used to set externally while calibrating
+                std::string vehicle_type = d["vehicleType"].GetString();
+                if (vehicle_type.compare("Truck") == 0) {
+                    GuessTruck80Par(bearing_capacity, width, (t_params._r0 - rimRadius) / width, 2 * rimRadius, p_li,
+                                    p_use, t_params);
+                } else {
+                    GuessPassCar70Par(bearing_capacity, width, (t_params._r0 - rimRadius) / width, 2 * rimRadius, p_li,
+                                      p_use, t_params);
+                }
+            }
+
+        } else {  // If high level params is false, then user should have provided the low level params
+            t_params._jw = d["jw"].GetDouble();
+            t_params._rr = d["rr"].GetDouble();
+            t_params._r0 = d["r0"].GetDouble();
+            t_params._pn = d["pn"].GetDouble();
+            t_params._pnmax = d["pnmax"].GetDouble();
+            t_params._kt = d["kt"].GetDouble();
+            t_params._rdyncoPn = d["rdyncoPn"].GetDouble();
+            t_params._rdyncoP2n = d["rdyncoP2n"].GetDouble();
+            t_params._fzRdynco = d["fzRdynco"].GetDouble();
+            t_params._rdyncoCrit = d["rdyncoCrit"].GetDouble();
+
+            t_params._dfx0Pn = d["dfx0Pn"].GetDouble();
+            t_params._dfx0P2n = d["dfx0P2n"].GetDouble();
+            t_params._fxmPn = d["fxmPn"].GetDouble();
+            t_params._fxmP2n = d["fxmP2n"].GetDouble();
+            t_params._fxsPn = d["fxsPn"].GetDouble();
+            t_params._fxsP2n = d["fxsP2n"].GetDouble();
+            t_params._sxmPn = d["sxmPn"].GetDouble();
+            t_params._sxmP2n = d["sxmP2n"].GetDouble();
+            t_params._sxsPn = d["sxsPn"].GetDouble();
+            t_params._sxsP2n = d["sxsP2n"].GetDouble();
+
+            t_params._dfy0Pn = d["dfy0Pn"].GetDouble();
+            t_params._dfy0P2n = d["dfy0P2n"].GetDouble();
+            t_params._fymPn = d["fymPn"].GetDouble();
+            t_params._fymP2n = d["fymP2n"].GetDouble();
+            t_params._fysPn = d["fysPn"].GetDouble();
+            t_params._fysP2n = d["fysP2n"].GetDouble();
+            t_params._symPn = d["symPn"].GetDouble();
+            t_params._symP2n = d["symP2n"].GetDouble();
+            t_params._sysPn = d["sysPn"].GetDouble();
+            t_params._sysP2n = d["sysP2n"].GetDouble();
+        }
+
+    } else {
+        t_params._jw = d["jw"].GetDouble();
+        t_params._rr = d["rr"].GetDouble();
+        t_params._r0 = d["r0"].GetDouble();
+        t_params._pn = d["pn"].GetDouble();
+        t_params._pnmax = d["pnmax"].GetDouble();
+        t_params._kt = d["kt"].GetDouble();
+        t_params._rdyncoPn = d["rdyncoPn"].GetDouble();
+        t_params._rdyncoP2n = d["rdyncoP2n"].GetDouble();
+        t_params._fzRdynco = d["fzRdynco"].GetDouble();
+        t_params._rdyncoCrit = d["rdyncoCrit"].GetDouble();
+
+        t_params._dfx0Pn = d["dfx0Pn"].GetDouble();
+        t_params._dfx0P2n = d["dfx0P2n"].GetDouble();
+        t_params._fxmPn = d["fxmPn"].GetDouble();
+        t_params._fxmP2n = d["fxmP2n"].GetDouble();
+        t_params._fxsPn = d["fxsPn"].GetDouble();
+        t_params._fxsP2n = d["fxsP2n"].GetDouble();
+        t_params._sxmPn = d["sxmPn"].GetDouble();
+        t_params._sxmP2n = d["sxmP2n"].GetDouble();
+        t_params._sxsPn = d["sxsPn"].GetDouble();
+        t_params._sxsP2n = d["sxsP2n"].GetDouble();
+
+        t_params._dfy0Pn = d["dfy0Pn"].GetDouble();
+        t_params._dfy0P2n = d["dfy0P2n"].GetDouble();
+        t_params._fymPn = d["fymPn"].GetDouble();
+        t_params._fymP2n = d["fymP2n"].GetDouble();
+        t_params._fysPn = d["fysPn"].GetDouble();
+        t_params._fysP2n = d["fysP2n"].GetDouble();
+        t_params._symPn = d["symPn"].GetDouble();
+        t_params._symP2n = d["symP2n"].GetDouble();
+        t_params._sysPn = d["sysPn"].GetDouble();
+        t_params._sysP2n = d["sysP2n"].GetDouble();
+    }
+}
+
+// Utility functions that guess the tire parameters for a TMeasy tire based on standard tire specifications that user
+// can get from a spec sheet These functions are directly copy pasted from Chrono with minor modifications
+
+// Function to compute the max tire load from the load index specified by the user
+__host__ double d18::GetTireMaxLoad(unsigned int li) {
+    double Weight_per_Tire[] = {
+        45,    46.5,  47.5,   48.7,   50,     51.5,   53,     54.5,   56,     58,     60,     61.5,   63,     65,
+        67,    69,    71,     73,     75,     77.5,   80.0,   82.5,   85.0,   87.5,   90.0,   92.5,   95.0,   97.5,
+        100.0, 103,   106,    109,    112,    115,    118,    121,    125,    128,    132,    136,    140,    145,
+        150,   155,   160,    165,    170,    175,    180,    185,    190,    195,    200,    206,    212,    218,
+        224,   230,   236,    243,    250,    257,    265,    272,    280,    290,    300,    307,    315,    325,
+        335,   345,   355,    365,    375,    387,    400,    412,    425,    437,    450,    462,    475,    487,
+        500,   515,   530,    545,    560,    580,    600,    615,    630,    650,    670,    690,    710,    730,
+        750,   775,   800,    825,    850,    875,    900,    925,    950,    975,    1000,   1030,   1060,   1090,
+        1120,  1150,  1180,   1215,   1250,   1285,   1320,   1360,   1400,   1450,   1500,   1550,   1600,   1650,
+        1700,  1750,  1800,   1850,   1900,   1950,   2000,   2060,   2120,   2180,   2240,   2300,   2360,   2430,
+        2500,  2575,  2650,   2725,   2800,   2900,   3000,   3075,   3150,   3250,   3350,   3450,   3550,   3650,
+        3750,  3875,  4000,   4125,   4250,   4375,   4500,   4625,   4750,   4875,   5000,   5150,   5300,   5450,
+        5600,  5850,  6000,   6150,   6300,   6500,   6700,   6900,   7100,   7300,   7500,   7750,   8000,   8250,
+        8500,  8750,  9000,   9250,   9500,   9750,   10000,  10300,  10600,  10900,  11200,  11500,  11800,  12150,
+        12500, 12850, 13200,  13600,  14000,  14500,  15000,  15550,  16000,  16500,  17000,  17500,  18000,  18500,
+        19000, 19500, 20000,  20600,  21200,  21800,  22400,  23000,  23600,  24300,  25000,  25750,  26500,  27250,
+        28000, 29000, 30000,  30750,  31500,  32500,  33500,  34500,  35500,  36500,  37500,  38750,  40000,  41250,
+        42500, 43750, 45000,  46250,  47500,  48750,  50000,  51500,  53000,  54500,  56000,  58000,  60000,  61500,
+        63000, 65000, 67000,  69000,  71000,  73000,  75000,  77500,  80000,  82500,  85000,  87500,  90000,  92500,
+        95000, 97500, 100000, 103000, 106000, 109000, 112000, 115000, 118000, 121000, 125000, 128500, 132000, 136000};
+
+    unsigned int nw = sizeof(Weight_per_Tire) / sizeof(double);
+    const double g = 9.81;
+    double fmax;
+    if (li < nw) {
+        fmax = Weight_per_Tire[li] * g;
+    } else {
+        fmax = Weight_per_Tire[nw - 1] * g;
+    }
+    return fmax;
+}
+
+// Guessing tire parameters for a truck tire
+__host__ void d18::GuessTruck80Par(unsigned int li,          // tire load index
+                                   double tireWidth,         // [m]
+                                   double ratio,             // [] = use 0.75 meaning 75%
+                                   double rimDia,            // rim diameter [m]
+                                   double pinfl_li,          // inflation pressure at load index
+                                   double pinfl_use,         // inflation pressure in this configuration
+                                   TMeasyNrParam& t_params)  // damping ratio
+{
+    double tireLoad = GetTireMaxLoad(li);
+    GuessTruck80Par(tireLoad, tireWidth, ratio, rimDia, pinfl_li, pinfl_use, t_params);
+}
+__host__ void d18::GuessTruck80Par(double tireLoad,   // tire load index
+                                   double tireWidth,  // [m]
+                                   double ratio,      // [] = use 0.75 meaning 75%
+                                   double rimDia,     // rim diameter [m]
+                                   double pinfl_li,   // inflation pressure at load index
+                                   double pinfl_use,  // inflation pressure in this configuration
+                                   TMeasyNrParam& t_params) {
+    // damping ratio{
+    double secth = tireWidth * ratio;  // tire section height
+    double defl_max = 0.16 * secth;    // deflection at tire payload
+
+    t_params._pn = 0.5 * tireLoad * pow(pinfl_use / pinfl_li, 0.8);
+    t_params._pnmax = 3.5 * t_params._pn;
+
+    double CZ = tireLoad / defl_max;
+
+    t_params._kt = CZ;  // Set the tire vertical stiffness
+
+    t_params._rim_radius = 0.5 * rimDia;
+
+    t_params._width = tireWidth;
+
+    // Normalized Parameters gained from data set containing original data from Pacejka book
+    t_params._dfx0Pn = 17.7764 * t_params._pn;
+    t_params._dfx0P2n = 14.5301 * 2.0 * t_params._pn;
+    t_params._fxmPn = 0.89965 * t_params._pn;
+    t_params._fxmP2n = 0.77751 * 2.0 * t_params._pn;
+    t_params._fxsPn = 0.46183 * t_params._pn;
+    t_params._fxsP2n = 0.42349 * 2.0 * t_params._pn;
+    t_params._sxmPn = 0.10811;
+    t_params._sxmP2n = 0.12389;
+    t_params._sxsPn = 0.66667;
+    t_params._sxsP2n = 0.66667;
+    t_params._dfy0Pn = 7.4013 * t_params._pn;
+    t_params._dfy0P2n = 6.8505 * 2.0 * t_params._pn;
+    t_params._fymPn = 0.75876 * t_params._pn;
+    t_params._fymP2n = 0.72628 * 2.0 * t_params._pn;
+    t_params._fysPn = 0.68276 * t_params._pn;
+    t_params._fysP2n = 0.65319 * 2.0 * t_params._pn;
+    t_params._symPn = 0.33167;
+    t_params._symP2n = 0.33216;
+    t_params._sysPn = 1.0296;
+    t_params._sysP2n = 1.0296;
+}
+
+// Guessing tire parameters for a passenger car
+__host__ void d18::GuessPassCar70Par(unsigned int li,          // tire load index
+                                     double tireWidth,         // [m]
+                                     double ratio,             // [] = use 0.75 meaning 75%
+                                     double rimDia,            // rim diameter [m]
+                                     double pinfl_li,          // inflation pressure at load index
+                                     double pinfl_use,         // inflation pressure in this configuration
+                                     TMeasyNrParam& t_params)  // damping ratio
+{
+    double tireLoad = GetTireMaxLoad(li);
+    GuessPassCar70Par(tireLoad, tireWidth, ratio, rimDia, pinfl_li, pinfl_use, t_params);
+}
+__host__ void d18::GuessPassCar70Par(double tireLoad,            // tire load index
+                                     double tireWidth,           // [m]
+                                     double ratio,               // [] = use 0.75 meaning 75%
+                                     double rimDia,              // rim diameter [m]
+                                     double pinfl_li,            // inflation pressure at load index
+                                     double pinfl_use,           // inflation pressure in this configuration
+                                     TMeasyNrParam& t_params) {  // damping ratio
+    double secth = tireWidth * ratio;                            // tire section height
+    double defl_max = 0.16 * secth;                              // deflection at tire payload
+
+    t_params._pn = 0.5 * tireLoad * pow(pinfl_use / pinfl_li, 0.8);
+    t_params._pnmax = 3.5 * t_params._pn;
+
+    double CZ = tireLoad / defl_max;
+
+    t_params._kt = CZ;  // Set the tire vertical stiffness
+
+    t_params._rim_radius = 0.5 * rimDia;
+
+    t_params._width = tireWidth;
+
+    // Normalized Parameters gained from data set containing original data from Pacejka book
+    t_params._dfx0Pn = 18.3741 * t_params._pn;
+    t_params._dfx0P2n = 19.4669 * 2.0 * t_params._pn;
+    t_params._fxmPn = 1.1292 * t_params._pn;
+    t_params._fxmP2n = 1.0896 * 2.0 * t_params._pn;
+    t_params._fxsPn = 0.80149 * t_params._pn;
+    t_params._fxsP2n = 0.76917 * 2.0 * t_params._pn;
+    t_params._sxmPn = 0.13913;
+    t_params._sxmP2n = 0.13913;
+    t_params._sxsPn = 0.66667;
+    t_params._sxsP2n = 0.66667;
+    t_params._dfy0Pn = 15.9826 * t_params._pn;
+    t_params._dfy0P2n = 12.8509 * 2.0 * t_params._pn;
+    t_params._fymPn = 1.0009 * t_params._pn;
+    t_params._fymP2n = 0.91367 * 2.0 * t_params._pn;
+    t_params._fysPn = 0.8336 * t_params._pn;
+    t_params._fysP2n = 0.77336 * 2.0 * t_params._pn;
+    t_params._symPn = 0.14852;
+    t_params._symP2n = 0.18504;
+    t_params._sysPn = 0.96524;
+    t_params._sysP2n = 1.0714;
+}

--- a/wheeled_vehicle_models/18dof-gpu/dof18_gpu.cuh
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_gpu.cuh
@@ -1,0 +1,731 @@
+#ifndef DOF18_H
+#define DOF18_H
+
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "utils_gpu.cuh"
+// enum to decide what type of tire we have
+enum class TireType { TMeasy, TMeasyNr };
+
+namespace d18 {
+
+// TMeasy parameter structure
+struct TMeasyParam {
+    // constructor that takes default values of HMMWV
+    __device__ __host__ TMeasyParam()
+        : _jw(6.69),
+          _rr(0.015),
+          _mu(0.8),
+          _r0(0.4699),
+          _pn(8562.8266),
+          _pnmax(29969.893),
+          _cx(185004.42),
+          _cy(164448.37),
+          _kt(411121.0),
+          _dx(3700.),
+          _dy(3488.),
+          _rdyncoPn(0.375),
+          _rdyncoP2n(0.75),
+          _fzRdynco(0),
+          _rdyncoCrit(0),
+          _dfx0Pn(151447.29),
+          _dfx0P2n(236412.79),
+          _fxmPn(7575.3614),
+          _fxmP2n(12808.276),
+          _fxsPn(4657.9208),
+          _fxsP2n(8625.3352),
+          _sxmPn(0.12),
+          _sxmP2n(0.15),
+          _sxsPn(0.9),
+          _sxsP2n(0.95),
+          _dfy0Pn(50931.693),
+          _dfy0P2n(94293.847),
+          _fymPn(6615.0404),
+          _fymP2n(12509.947),
+          _fysPn(6091.5092),
+          _fysP2n(11443.875),
+          _symPn(0.38786),
+          _symP2n(0.38786),
+          _sysPn(0.82534),
+          _sysP2n(0.91309) {}
+
+    // copy constructor
+    __device__ __host__ TMeasyParam(const TMeasyParam* other)
+        : _jw(other->_jw),
+          _rr(other->_rr),
+          _mu(other->_mu),
+          _r0(other->_r0),
+          _pn(other->_pn),
+          _pnmax(other->_pnmax),
+          _cx(other->_cx),
+          _cy(other->_cy),
+          _kt(other->_kt),
+          _dx(other->_dx),
+          _dy(other->_dy),
+          _rdyncoPn(other->_rdyncoPn),
+          _rdyncoP2n(other->_rdyncoP2n),
+          _fzRdynco(other->_fzRdynco),
+          _rdyncoCrit(other->_rdyncoCrit),
+          _dfx0Pn(other->_dfx0Pn),
+          _dfx0P2n(other->_dfx0P2n),
+          _fxmPn(other->_fxmPn),
+          _fxmP2n(other->_fxmP2n),
+          _fxsPn(other->_fxsPn),
+          _fxsP2n(other->_fxsP2n),
+          _sxmPn(other->_sxmPn),
+          _sxmP2n(other->_sxmP2n),
+          _sxsPn(other->_sxsPn),
+          _sxsP2n(other->_sxsP2n),
+          _dfy0Pn(other->_dfy0Pn),
+          _dfy0P2n(other->_dfy0P2n),
+          _fymPn(other->_fymPn),
+          _fymP2n(other->_fymP2n),
+          _fysPn(other->_fysPn),
+          _fysP2n(other->_fysP2n),
+          _symPn(other->_symPn),
+          _symP2n(other->_symP2n),
+          _sysPn(other->_sysPn),
+          _sysP2n(other->_sysP2n) {}
+
+    // basic tire parameters
+    double _jw;  // wheel inertia
+    double _rr;  // rolling resistance of tire
+    double _mu;  // friction constant
+    double _r0;  // unloaded tire radius
+
+    // TM easy specific tire params
+    double _pn, _pnmax;    // nominal and max vertical force
+    double _cx, _cy, _kt;  // longitudinal, lateral and vertical stiffness
+    double _dx,
+        _dy;  // longitudinal and lateral damping coeffs. No vertical damping
+
+    // TM easy force characteristic params
+    // 2 values - one at nominal load and one at max load
+
+    // dynamic radius weighting coefficient and a critical value for the
+    // vertical force
+    double _rdyncoPn, _rdyncoP2n, _fzRdynco, _rdyncoCrit;
+
+    // Longitudinal
+    double _dfx0Pn, _dfx0P2n;  // intial longitudinal slopes dFx/dsx [N]
+    double _fxmPn, _fxmP2n;    // maximum longituidnal force [N]
+    double _fxsPn, _fxsP2n;    // Longitudinal load at sliding [N]
+    double _sxmPn, _sxmP2n;    // slip sx at maximum longitudinal load Fx
+    double _sxsPn, _sxsP2n;    // slip sx where sliding begins
+    // Lateral
+    double _dfy0Pn, _dfy0P2n;  // intial lateral slopes dFx/dsx [N]
+    double _fymPn, _fymP2n;    // maximum lateral force [N]
+    double _fysPn, _fysP2n;    // Lateral load at sliding [N]
+    double _symPn, _symP2n;    // slip sx at maximum lateral load Fx
+    double _sysPn, _sysP2n;    // slip sx where sliding begins
+};
+
+// Tm easy state structure - actual states + things that we need to keep track
+// of
+struct TMeasyState {
+    // default contructor to 0's
+    __device__ __host__ TMeasyState()
+        : _xe(0.),
+          _ye(0.),
+          _xedot(0.),
+          _yedot(0.),
+          _omega(0.),
+          _dOmega(0),
+          _xt(0.),
+          _rStat(0.),
+          _fx(0.),
+          _fy(0.),
+          _fz(0.),
+          _vsx(0.),
+          _vsy(0.),
+          _My(0.),
+          _engTor(0.) {}
+
+    // special constructor in case we want to start the simualtion at
+    // some other time step
+    __device__ __host__ TMeasyState(double xe,
+                                    double ye,
+                                    double xedot,
+                                    double yedot,
+                                    double omega,
+                                    double xt,
+                                    double rStat,
+                                    double fx,
+                                    double fy,
+                                    double fz,
+                                    double vsx,
+                                    double vsy,
+                                    double init_ratio)
+        : _xe(xe),
+          _ye(ye),
+          _xedot(xedot),
+          _yedot(yedot),
+          _omega(omega),
+          _xt(xt),
+          _rStat(rStat),
+          _fx(fx),
+          _fy(fy),
+          _fz(fz),
+          _vsx(vsx),
+          _vsy(vsy) {}
+
+    // Copy constructor
+    __device__ __host__ TMeasyState(const TMeasyState* other)
+        : _xe(other->_xe),
+          _ye(other->_ye),
+          _xedot(other->_xedot),
+          _yedot(other->_yedot),
+          _omega(other->_omega),
+          _dOmega(other->_dOmega),
+          _xt(other->_xt),
+          _rStat(other->_rStat),
+          _fx(other->_fx),
+          _fy(other->_fy),
+          _fz(other->_fz),
+          _vsx(other->_vsx),
+          _vsy(other->_vsy),
+          _My(other->_My),
+          _engTor(other->_engTor) {}
+
+    // the actual state that are intgrated
+    double _xe, _ye;        // long and lat tire deflection
+    double _xedot, _yedot;  // long and lat tire deflection velocity
+    double _omega;          // angular velocity of wheel
+    double _dOmega;         // angular velocity dot
+
+    // other "states" that we need to keep track of
+    double _xt;            // vertical tire compression
+    double _rStat;         // loaded tire radius
+    double _fx, _fy, _fz;  // long, lateral and vertical force in tire frame
+
+    // velocities in tire frame
+    double _vsx, _vsy;
+
+    double _My;  // Rolling resistance moment (negetive)
+
+    // torque from engine that we keep track of
+    double _engTor;
+};
+
+struct TMeasyNrParam {
+    // default constructor just assigns zero to all members
+    __device__ __host__ TMeasyNrParam()
+        : _jw(6.69),
+          _rr(0.015),
+          _mu(0.8),
+          _r0(0.4699),
+          _width(0.245),
+          _rim_radius(0.254),
+          _pn(8562.8266),
+          _pnmax(29969.893),
+          _kt(411121.0),
+          _rdyncoPn(0.375),
+          _rdyncoP2n(0.75),
+          _fzRdynco(0),
+          _rdyncoCrit(0),
+          _dfx0Pn(151447.29),
+          _dfx0P2n(236412.79),
+          _fxmPn(7575.3614),
+          _fxmP2n(12808.276),
+          _fxsPn(4657.9208),
+          _fxsP2n(8625.3352),
+          _sxmPn(0.12),
+          _sxmP2n(0.15),
+          _sxsPn(0.9),
+          _sxsP2n(0.95),
+          _dfy0Pn(50931.693),
+          _dfy0P2n(94293.847),
+          _fymPn(6615.0404),
+          _fymP2n(12509.947),
+          _fysPn(6091.5092),
+          _fysP2n(11443.875),
+          _symPn(0.38786),
+          _symP2n(0.38786),
+          _sysPn(0.82534),
+          _sysP2n(0.91309),
+          _vcoulomb(1.0),
+          _frblend_begin(1.),
+          _frblend_end(3.),
+          _bearingCapacity(10000),
+          _li(90),
+          _p_li(1.),
+          _p_use(1.) {}
+    // copy constructor
+    __device__ __host__ TMeasyNrParam(const TMeasyNrParam* other)
+        : _jw(other->_jw),
+          _rr(other->_rr),
+          _mu(other->_mu),
+          _r0(other->_r0),
+          _width(other->_width),
+          _rim_radius(other->_rim_radius),
+          _pn(other->_pn),
+          _pnmax(other->_pnmax),
+          _kt(other->_kt),
+          _rdyncoPn(other->_rdyncoPn),
+          _rdyncoP2n(other->_rdyncoP2n),
+          _fzRdynco(other->_fzRdynco),
+          _rdyncoCrit(other->_rdyncoCrit),
+          _dfx0Pn(other->_dfx0Pn),
+          _dfx0P2n(other->_dfx0P2n),
+          _fxmPn(other->_fxmPn),
+          _fxmP2n(other->_fxmP2n),
+          _fxsPn(other->_fxsPn),
+          _fxsP2n(other->_fxsP2n),
+          _sxmPn(other->_sxmPn),
+          _sxmP2n(other->_sxmP2n),
+          _sxsPn(other->_sxsPn),
+          _sxsP2n(other->_sxsP2n),
+          _dfy0Pn(other->_dfy0Pn),
+          _dfy0P2n(other->_dfy0P2n),
+          _fymPn(other->_fymPn),
+          _fymP2n(other->_fymP2n),
+          _fysPn(other->_fysPn),
+          _fysP2n(other->_fysP2n),
+          _symPn(other->_symPn),
+          _symP2n(other->_symP2n),
+          _sysPn(other->_sysPn),
+          _sysP2n(other->_sysP2n),
+          _vcoulomb(other->_vcoulomb),
+          _frblend_begin(other->_frblend_begin),
+          _frblend_end(other->_frblend_end),
+          _bearingCapacity(other->_bearingCapacity),
+          _li(other->_li),
+          _p_li(other->_p_li),
+          _p_use(other->_p_use) {}
+
+    double _jw;          // wheel inertia
+    double _rr;          // Rolling Resistance
+    double _mu;          // Local friction coefficient between tire and road
+    double _r0;          // unloaded tire radius
+    double _width;       // tire width
+    double _rim_radius;  // rim radius
+    double _pn;          // nominal vertical force
+    double _pnmax;       // max vertical force
+    double _kt;          // vertical tire stiffness
+    double _rdyncoPn;    // dynamic radius weighting coefficient at nominal load
+    double _rdyncoP2n;   // dynamic radius weighting coefficient at max load
+    double _fzRdynco;    // critical value for the vertical force
+    double _rdyncoCrit;
+    // Longitudinal
+    double _dfx0Pn, _dfx0P2n;  // Initial longitudinal slopes dFx/dsx [N]
+    double _fxmPn, _fxmP2n;    // Maximum longituidnal force [N]
+    double _fxsPn, _fxsP2n;    // Longitudinal load at sliding [N]
+    double _sxmPn, _sxmP2n;    // slip sx at maximum longitudinal load Fx
+    double _sxsPn, _sxsP2n;    // slip sx where sliding begins
+    // Lateral
+    double _dfy0Pn, _dfy0P2n;  // intial lateral slopes dFx/dsx [N]
+    double _fymPn, _fymP2n;    // maximum lateral force [N]
+    double _fysPn, _fysP2n;    // Lateral load at sliding [N]
+    double _symPn, _symP2n;    // slip sx at maximum lateral load Fx
+    double _sysPn, _sysP2n;    // slip sx where sliding begins
+    double _vcoulomb;          // Velocity below which we care about static friction
+    double _frblend_begin;     // Beginning of friction blending
+    double _frblend_end;       // End of friction blending
+    double _bearingCapacity;   // High level tire parameters that define all other parameters that the user can set
+    double _li;                // Load index
+    double _p_li;              // Pressure at load index
+    double _p_use;             // Pressure at which the tire is used
+};
+
+struct TMeasyNrState {
+    __device__ __host__ TMeasyNrState()
+        : _omega(0.),
+          _dOmega(0),
+          _xt(0.),
+          _rStat(0.),
+          _fx(0.),
+          _fy(0.),
+          _fz(0.),
+          _vsx(0.),
+          _vsy(0.),
+          _My(0.),
+          _engTor(0.) {}
+
+    // Copy constructor
+    __device__ __host__ TMeasyNrState(const TMeasyNrState* other)
+        : _omega(other->_omega),
+          _dOmega(other->_dOmega),
+          _xt(other->_xt),
+          _rStat(other->_rStat),
+          _fx(other->_fx),
+          _fy(other->_fy),
+          _fz(other->_fz),
+          _vsx(other->_vsx),
+          _vsy(other->_vsy),
+          _My(other->_My),
+          _engTor(other->_engTor) {}
+
+    // Wheel states that are set as tire states
+    double _omega;   // angular velocity of wheel
+    double _dOmega;  // angular velocity dot
+
+    // Other "states" that we need to keep track of
+    double _xt;            // vertical tire compression
+    double _rStat;         // loaded tire radius
+    double _fx, _fy, _fz;  // long, lateral and vertical force in tire frame
+
+    // Velocities in the tire frame
+    double _vsx, _vsy;
+
+    double _My;  // Rolling resistance moment (negetive)
+
+    // Torque from engine that we keep track of
+    double _engTor;
+};
+
+// vehicle Parameters structure
+struct VehicleParam {
+    // default constructor with pre tuned values from HMMVW calibration
+    __device__ __host__ VehicleParam()
+        : _a(1.6889),
+          _b(1.6889),
+          _h(0.713),
+          _m(2097.85),
+          _jz(4519.),
+          _jx(1289.),
+          _jxz(3.265),
+          _cf(1.82),
+          _cr(1.82),
+          _muf(127.866),
+          _mur(129.98),
+          _hrcf(0.379),
+          _hrcr(0.327),
+          _krof(31000),
+          _kror(31000),
+          _brof(3300),
+          _bror(3300),
+          _nonLinearSteer(false),
+          _maxSteer(0.6525249),
+          _crankInertia(1.1),
+          _tcbool(false),
+          _maxBrakeTorque(4000.),
+          _throttleMod(0),
+          _driveType(1),
+          _whichWheels(1) {}
+
+    // Copy constructor
+    __device__ __host__ VehicleParam(const VehicleParam* other)
+        : _a(other->_a),
+          _b(other->_b),
+          _h(other->_h),
+          _m(other->_m),
+          _jz(other->_jz),
+          _jx(other->_jx),
+          _jxz(other->_jxz),
+          _cf(other->_cf),
+          _cr(other->_cr),
+          _muf(other->_muf),
+          _mur(other->_mur),
+          _hrcf(other->_hrcf),
+          _hrcr(other->_hrcr),
+          _krof(other->_krof),
+          _kror(other->_kror),
+          _brof(other->_brof),
+          _bror(other->_bror),
+          _nonLinearSteer(other->_nonLinearSteer),
+          _maxSteer(other->_maxSteer),
+          _crankInertia(other->_crankInertia),
+          _tcbool(other->_tcbool),
+          _maxBrakeTorque(other->_maxBrakeTorque),
+          _throttleMod(other->_throttleMod),
+          _driveType(other->_driveType),
+          _whichWheels(other->_whichWheels),
+          _steerMap(other->_steerMap),
+          _steerMapSize(other->_steerMapSize),
+          _gearRatios(other->_gearRatios),
+          _noGears(other->_noGears),
+          _powertrainMap(other->_powertrainMap),
+          _powertrainMapSize(other->_powertrainMapSize),
+          _lossesMap(other->_lossesMap),
+          _lossesMapSize(other->_lossesMapSize),
+          _CFmap(other->_CFmap),
+          _CFmapSize(other->_CFmapSize),
+          _TRmap(other->_TRmap),
+          _TRmapSize(other->_TRmapSize),
+          _shiftMap(other->_shiftMap) {}
+
+    double _a, _b;        // distance c.g. - front axle & distance c.g. - rear axle (m)
+    double _h;            // height of c.g
+    double _m;            // total vehicle mass (kg)
+    double _jz;           // yaw moment inertia (kg.m^2)
+    double _jx;           // roll inertia
+    double _jxz;          // XZ inertia
+    double _cf, _cr;      // front and rear track width
+    double _muf, _mur;    // front and rear unsprung mass
+    double _hrcf, _hrcr;  // front and rear roll centre height below C.g
+    double _krof, _kror, _brof,
+        _bror;  // front and rear roll stiffness and damping
+
+    // Bool that checks if the steering is non linea ---> Need to depricate
+    // this, can always define a steer map 1 -> Steering is non linear, requires
+    // a steering map defined - example in json 0 -> Steering is linear. Need
+    // only a max steer defined. The normalized sterring then just multiplies
+    // against this value to give a wheel angle
+    bool _nonLinearSteer;
+    // Non linear steering map in case the steering mechanism is not linear
+    MapEntry* _steerMap;
+    int _steerMapSize;
+
+    // max steer angle parameters of the vehicle
+    double _maxSteer;
+
+    // crank shaft inertia
+    double _crankInertia;
+    // some gear parameters
+    double* _gearRatios;  // gear ratio's
+    int _noGears;         // number of gears
+
+    // Additionally we have a shift map that needs to always be filled,
+    // This can either be filled by setting the same upshift and downshift RPM
+    // for all the gears or by setting upshift and downshift RPM for each of the
+    // gears - please see the demo JSON file for an example
+    MapEntry* _shiftMap;
+
+    // boolean for torque converter presense
+    bool _tcbool;
+
+    // double _maxTorque; // Max torque
+    double _maxBrakeTorque;  // max brake torque
+
+    // Bool that defines how the throttle modulates the maps
+    // 1 -> Modulates like in a motor -> Modifies the entire torque and RPM map
+    // 0 -> Modulates like in an engine -> multiplies only against the torque -
+    // > Default
+    bool _throttleMod;
+    // We will always define the powertrain with a map
+    MapEntry* _powertrainMap;
+    int _powertrainMapSize;
+    MapEntry* _lossesMap;
+    int _lossesMapSize;
+
+    // torque converter maps
+    MapEntry* _CFmap;  // capacity factor map
+    int _CFmapSize;
+    MapEntry* _TRmap;  // Torque ratio map
+    int _TRmapSize;
+
+    // Flag for wether we have an 4WD or 2WD
+    // 1-> 4WD - This is the default
+    // 0 -> 2WD - To set this, the JSON entry needs to be added.
+    bool _driveType;
+
+    // If we have a 2WD vehicle this bool specifies which of the 2 wheels are
+    // powered 1 -> Rear wheels are powered 0 -> Front wheels are powered
+    bool _whichWheels;
+};
+
+// vehicle states structure
+struct VehicleState {
+    // default constructor just assigns zero to all members
+    __device__ __host__ VehicleState()
+        : _x(0.),
+          _y(0.),
+          _dx(0),
+          _dy(0),
+          _u(0.),
+          _v(0.),
+          _psi(0.),
+          _wz(0.),
+          _phi(0.),
+          _wx(0.),
+          _udot(0.),
+          _vdot(0.),
+          _wxdot(0.),
+          _wzdot(0.),
+          _tor(0.),
+          _crankOmega(0.),
+          _current_gr(0) {}
+
+    // copy constructor
+    __device__ __host__ VehicleState(const VehicleState* other)
+        : _x(other->_x),
+          _y(other->_y),
+          _dx(other->_dx),
+          _dy(other->_dy),
+          _u(other->_u),
+          _v(other->_v),
+          _psi(other->_psi),
+          _wz(other->_wz),
+          _phi(other->_phi),
+          _wx(other->_wx),
+          _udot(other->_udot),
+          _vdot(other->_vdot),
+          _wxdot(other->_wxdot),
+          _wzdot(other->_wzdot),
+          _tor(other->_tor),
+          _crankOmega(other->_crankOmega),
+          _dOmega_crank(other->_dOmega_crank),
+          _current_gr(other->_current_gr) {}
+
+    // special constructor in case need to start simulation
+    // from some other state
+    double _x, _y;     // x and y position
+    double _dx, _dy;   // This is basically u and v but transformed to global coordinates
+    double _u, _v;     // x and y velocity
+    double _psi, _wz;  // yaw angle and yaw rate
+    double _phi, _wx;  // roll angle and roll rate
+
+    // acceleration 'states'
+    double _udot, _vdot;
+    double _wxdot, _wzdot;
+
+    // crank torque (used to transmit torque to tires) and crank angular
+    // velocity state
+    double _tor;
+    double _crankOmega;
+    double _dOmega_crank;
+    int _current_gr;
+};
+
+// ------------------------------------------------------------------------------
+// Vehicle functions
+
+__device__ double driveTorque(const VehicleParam* v_params, const double throttle, const double omega);
+
+__device__ inline double brakeTorque(const VehicleParam* v_params, const double brake) {
+    return v_params->_maxBrakeTorque * brake;
+}
+__device__ void differentialSplit(double torque,
+                                  double max_bias,
+                                  double speed_left,
+                                  double speed_right,
+                                  double* torque_left,
+                                  double* torque_right);
+
+// setting vehicle parameters using a JSON file
+__host__ void setVehParamsJSON(VehicleParam& v_params, const char* fileName);
+
+__device__ void vehToTireTransform(TMeasyState* tirelf_st,
+                                   TMeasyState* tirerf_st,
+                                   TMeasyState* tirelr_st,
+                                   TMeasyState* tirerr_st,
+                                   const VehicleState* v_states,
+                                   const double* loads,
+                                   const VehicleParam* v_params,
+                                   double steering);
+
+__device__ void vehToTireTransform(TMeasyNrState* tirelf_st,
+                                   TMeasyNrState* tirerf_st,
+                                   TMeasyNrState* tirelr_st,
+                                   TMeasyNrState* tirerr_st,
+                                   const VehicleState* v_states,
+                                   const double* loads,
+                                   const VehicleParam* v_params,
+                                   double steering);
+
+__device__ void tireToVehTransform(TMeasyState* tirelf_st,
+                                   TMeasyState* tirerf_st,
+                                   TMeasyState* tirelr_st,
+                                   TMeasyState* tirerr_st,
+                                   const VehicleState* v_states,
+                                   const VehicleParam* v_params,
+                                   double steering);
+
+__device__ void tireToVehTransform(TMeasyNrState* tirelf_st,
+                                   TMeasyNrState* tirerf_st,
+                                   TMeasyNrState* tirelr_st,
+                                   TMeasyNrState* tirerr_st,
+                                   const VehicleState* v_states,
+                                   const VehicleParam* v_params,
+                                   double steering);
+// ------------------------------ Tire functions
+
+// sets the vertical tire deflection based on the vehicle weight
+// template based on which tire
+__device__ __host__ void tireInit(TMeasyParam* t_params);
+__device__ __host__ void tireInit(TMeasyNrParam* t_params);
+
+// function to calculate the force from the force charactristics
+// used by tireSync
+__device__ void tmxy_combined(double* f, double* fos, double s, double df0, double sm, double fm, double ss, double fs);
+
+// Force function required by the TMeasy tire with no relaxation
+__device__ void
+computeCombinedColumbForce(double* fx, double* fy, double mu, double vsx, double vsy, double fz, double vcoulomb);
+// setting tire parameters using a JSON file
+__host__ void setTireParamsJSON(TMeasyParam& t_params, const char* fileName);
+// setting tire parameters using a JSON file for the TMeasy NR tire
+__host__ void setTireParamsJSON(TMeasyNrParam& t_params, const char* fileName);
+// Functions used in the RHS function for the external solver with overloads for the non-relaxation tire
+__device__ void computeTireLoads(double* loads,
+                                 const VehicleState* v_states,
+                                 const VehicleParam* v_params,
+                                 const TMeasyParam* t_params);
+
+__device__ void computeTireLoads(double* loads,
+                                 const VehicleState* v_states,
+                                 const VehicleParam* v_params,
+                                 const TMeasyNrParam* t_params);
+
+__device__ void computeTireRHS(TMeasyState* t_states,
+                               const TMeasyParam* t_params,
+                               const VehicleParam* v_params,
+                               double steering);
+__device__ void computeTireRHS(TMeasyNrState* t_states,
+                               const TMeasyNrParam* t_params,
+                               const VehicleParam* v_params,
+                               double steering);
+
+__device__ void computePowertrainRHS(VehicleState* v_states,
+                                     TMeasyState* tirelf_st,
+                                     TMeasyState* tirerf_st,
+                                     TMeasyState* tirelr_st,
+                                     TMeasyState* tirerr_st,
+                                     const VehicleParam* v_params,
+                                     const TMeasyParam* t_params,
+                                     const DriverInput* controls);
+
+__device__ void computePowertrainRHS(VehicleState* v_states,
+                                     TMeasyNrState* tirelf_st,
+                                     TMeasyNrState* tirerf_st,
+                                     TMeasyNrState* tirelr_st,
+                                     TMeasyNrState* tirerr_st,
+                                     const VehicleParam* v_params,
+                                     const TMeasyNrParam* t_params,
+                                     const DriverInput* controls);
+
+__device__ void computeVehRHS(VehicleState* v_states,
+                              const VehicleParam* v_params,
+                              const std::vector<double>* fx,
+                              const std::vector<double>* fy);
+
+// Additional tire functions to compute model required parameters from general parameters
+__host__ double GetTireMaxLoad(unsigned int li);
+// Functions to guess tire parameters from general tire specs
+__host__ void GuessTruck80Par(unsigned int li,
+                              double tireWidth,
+                              double ratio,
+                              double rimDia,
+                              double pinfl_li,
+                              double pinfl_use,
+                              TMeasyNrParam& t_params);
+
+__host__ void GuessTruck80Par(double tireLoad,
+                              double tireWidth,
+                              double ratio,
+                              double rimDia,
+                              double pinfl_li,
+                              double pinfl_use,
+                              TMeasyNrParam& t_params);
+
+__host__ void GuessPassCar70Par(unsigned int li,
+                                double tireWidth,
+                                double ratio,
+                                double rimDia,
+                                double pinfl_li,
+                                double pinfl_use,
+                                TMeasyNrParam& t_params);
+
+__host__ void GuessPassCar70Par(double tireLoad,
+                                double tireWidth,
+                                double ratio,
+                                double rimDia,
+                                double pinfl_li,
+                                double pinfl_use,
+                                TMeasyNrParam& t_params);
+
+}  // namespace d18
+
+#endif

--- a/wheeled_vehicle_models/18dof-gpu/dof18_gpu.cuh
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_gpu.cuh
@@ -637,13 +637,13 @@ struct VehicleState {
 
 // --------------------------------------------------------
 struct SimData {
-    SimData() : _driver_data(nullptr), _driver_data_len(0), _csv(" ") {}
+    SimData() : _driver_data(nullptr), _driver_data_len(0) {}
 
     SimData(VehicleParam veh_param,
             TMeasyParam tireTM_param,
             DriverInput* driver_data,
             const std::string& csv_writer_delim)
-        : _veh_param(veh_param), _tireTM_param(tireTM_param), _driver_data(driver_data), _csv(csv_writer_delim) {}
+        : _veh_param(veh_param), _tireTM_param(tireTM_param), _driver_data(driver_data) {}
 
     SimData(const SimData&) = delete;             // Delete copy constructor
     SimData& operator=(const SimData&) = delete;  // Delete copy assignment operator
@@ -656,17 +656,16 @@ struct SimData {
     TMeasyParam _tireTM_param;
     DriverInput* _driver_data;
     unsigned int _driver_data_len;
-    CSV_writer _csv;  // A csv writer in case state output needs to be stored
 };
 
 struct SimDataNr {
-    SimDataNr() : _driver_data(nullptr), _driver_data_len(0), _csv(" ") {}
+    SimDataNr() : _driver_data(nullptr), _driver_data_len(0) {}
 
     SimDataNr(VehicleParam veh_param,
               TMeasyNrParam tireTMNr_param,
               DriverInput* driver_data,
               const std::string& csv_writer_delim)
-        : _veh_param(veh_param), _tireTMNr_param(tireTMNr_param), _driver_data(driver_data), _csv(csv_writer_delim) {}
+        : _veh_param(veh_param), _tireTMNr_param(tireTMNr_param), _driver_data(driver_data) {}
 
     SimDataNr(const SimDataNr&) = delete;             // Delete copy constructor
     SimDataNr& operator=(const SimDataNr&) = delete;  // Delete copy assignment operator
@@ -679,7 +678,6 @@ struct SimDataNr {
     TMeasyNrParam _tireTMNr_param;
     DriverInput* _driver_data;
     unsigned int _driver_data_len;
-    CSV_writer _csv;  // A csv writer in case state output needs to be stored
 };
 // -------------------------------------------------------------------
 struct SimState {

--- a/wheeled_vehicle_models/18dof-gpu/dof18_gpu.cuh
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_gpu.cuh
@@ -637,10 +637,13 @@ struct VehicleState {
 
 // --------------------------------------------------------
 struct SimData {
-    SimData() : _driver_data(nullptr), _driver_data_len(0), _t_end(0.) {}
+    SimData() : _driver_data(nullptr), _driver_data_len(0), _csv(" ") {}
 
-    SimData(VehicleParam veh_param, TMeasyParam tireTM_param, DriverInput* driver_data, double t_end)
-        : _veh_param(veh_param), _tireTM_param(tireTM_param), _driver_data(driver_data), _t_end(t_end) {}
+    SimData(VehicleParam veh_param,
+            TMeasyParam tireTM_param,
+            DriverInput* driver_data,
+            const std::string& csv_writer_delim)
+        : _veh_param(veh_param), _tireTM_param(tireTM_param), _driver_data(driver_data), _csv(csv_writer_delim) {}
 
     SimData(const SimData&) = delete;             // Delete copy constructor
     SimData& operator=(const SimData&) = delete;  // Delete copy assignment operator
@@ -653,14 +656,17 @@ struct SimData {
     TMeasyParam _tireTM_param;
     DriverInput* _driver_data;
     unsigned int _driver_data_len;
-    double _t_end;
+    CSV_writer _csv;  // A csv writer in case state output needs to be stored
 };
 
 struct SimDataNr {
-    SimDataNr() : _driver_data(nullptr), _driver_data_len(0), _t_end(0.) {}
+    SimDataNr() : _driver_data(nullptr), _driver_data_len(0), _csv(" ") {}
 
-    SimDataNr(VehicleParam veh_param, TMeasyNrParam tireTMNr_param, DriverInput* driver_data, double t_end)
-        : _veh_param(veh_param), _tireTMNr_param(tireTMNr_param), _driver_data(driver_data), _t_end(t_end) {}
+    SimDataNr(VehicleParam veh_param,
+              TMeasyNrParam tireTMNr_param,
+              DriverInput* driver_data,
+              const std::string& csv_writer_delim)
+        : _veh_param(veh_param), _tireTMNr_param(tireTMNr_param), _driver_data(driver_data), _csv(csv_writer_delim) {}
 
     SimDataNr(const SimDataNr&) = delete;             // Delete copy constructor
     SimDataNr& operator=(const SimDataNr&) = delete;  // Delete copy assignment operator
@@ -673,7 +679,7 @@ struct SimDataNr {
     TMeasyNrParam _tireTMNr_param;
     DriverInput* _driver_data;
     unsigned int _driver_data_len;
-    double _t_end;
+    CSV_writer _csv;  // A csv writer in case state output needs to be stored
 };
 // -------------------------------------------------------------------
 struct SimState {
@@ -825,10 +831,7 @@ __device__ void computePowertrainRHS(VehicleState* v_states,
                                      const TMeasyNrParam* t_params,
                                      const DriverInput* controls);
 
-__device__ void computeVehRHS(VehicleState* v_states,
-                              const VehicleParam* v_params,
-                              const std::vector<double>* fx,
-                              const std::vector<double>* fy);
+__device__ void computeVehRHS(VehicleState* v_states, const VehicleParam* v_params, const double* fx, const double* fy);
 
 // Additional tire functions to compute model required parameters from general parameters
 __host__ double GetTireMaxLoad(unsigned int li);

--- a/wheeled_vehicle_models/18dof-gpu/dof18_gpu.cuh
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_gpu.cuh
@@ -343,6 +343,28 @@ struct TMeasyNrState {
           _My(0.),
           _engTor(0.) {}
 
+    __device__ __host__ TMeasyNrState(double omega,
+                                      double dOmega,
+                                      double xt,
+                                      double rStat,
+                                      double fx,
+                                      double fy,
+                                      double fz,
+                                      double vsx,
+                                      double vsy,
+                                      double My,
+                                      double engTor)
+        : _omega(omega),
+          _dOmega(dOmega),
+          _xt(xt),
+          _rStat(rStat),
+          _fx(fx),
+          _fy(fy),
+          _fz(fz),
+          _vsx(vsx),
+          _vsy(vsy),
+          _My(My),
+          _engTor(engTor) {}
     // Copy constructor
     __device__ __host__ TMeasyNrState(const TMeasyNrState* other)
         : _omega(other->_omega),
@@ -538,6 +560,40 @@ struct VehicleState {
           _crankOmega(0.),
           _current_gr(0) {}
 
+    __device__ __host__ VehicleState(double x,
+                                     double y,
+                                     double dx,
+                                     double dy,
+                                     double u,
+                                     double v,
+                                     double psi,
+                                     double wz,
+                                     double phi,
+                                     double wx,
+                                     double udot,
+                                     double vdot,
+                                     double wxdot,
+                                     double wzdot,
+                                     double tor,
+                                     double crankOmega,
+                                     int current_gr)
+        : _x(x),
+          _y(y),
+          _dx(dx),
+          _dy(dy),
+          _u(u),
+          _v(v),
+          _psi(psi),
+          _wz(wz),
+          _phi(phi),
+          _wx(wx),
+          _udot(udot),
+          _vdot(vdot),
+          _wxdot(wxdot),
+          _wzdot(wzdot),
+          _tor(tor),
+          _crankOmega(crankOmega),
+          _current_gr(current_gr) {}
     // copy constructor
     __device__ __host__ VehicleState(const VehicleState* other)
         : _x(other->_x),
@@ -577,6 +633,89 @@ struct VehicleState {
     double _crankOmega;
     double _dOmega_crank;
     int _current_gr;
+};
+
+// --------------------------------------------------------
+struct SimData {
+    SimData() : _driver_data(nullptr), _driver_data_len(0), _t_end(0.) {}
+
+    SimData(VehicleParam veh_param, TMeasyParam tireTM_param, DriverInput* driver_data, double t_end)
+        : _veh_param(veh_param), _tireTM_param(tireTM_param), _driver_data(driver_data), _t_end(t_end) {}
+
+    SimData(const SimData&) = delete;             // Delete copy constructor
+    SimData& operator=(const SimData&) = delete;  // Delete copy assignment operator
+
+    // Destructor
+    ~SimData() {
+        cudaFree(_driver_data);  // Assumes _driver_data was allocated with new[]
+    }
+    VehicleParam _veh_param;
+    TMeasyParam _tireTM_param;
+    DriverInput* _driver_data;
+    unsigned int _driver_data_len;
+    double _t_end;
+};
+
+struct SimDataNr {
+    SimDataNr() : _driver_data(nullptr), _driver_data_len(0), _t_end(0.) {}
+
+    SimDataNr(VehicleParam veh_param, TMeasyNrParam tireTMNr_param, DriverInput* driver_data, double t_end)
+        : _veh_param(veh_param), _tireTMNr_param(tireTMNr_param), _driver_data(driver_data), _t_end(t_end) {}
+
+    SimDataNr(const SimDataNr&) = delete;             // Delete copy constructor
+    SimDataNr& operator=(const SimDataNr&) = delete;  // Delete copy assignment operator
+
+    // Destructor
+    ~SimDataNr() {
+        cudaFree(_driver_data);  // Assumes _driver_data was allocated with new[]
+    }
+    VehicleParam _veh_param;
+    TMeasyNrParam _tireTMNr_param;
+    DriverInput* _driver_data;
+    unsigned int _driver_data_len;
+    double _t_end;
+};
+// -------------------------------------------------------------------
+struct SimState {
+    SimState() {}
+
+    SimState(VehicleState veh_state,
+             TMeasyState tirelf_state,
+             TMeasyState tirerf_state,
+             TMeasyState tirelr_state,
+             TMeasyState tirerr_state)
+        : _veh_state(veh_state),
+          _tirelf_state(tirelf_state),
+          _tirerf_state(tirerf_state),
+          _tirelr_state(tirelr_state),
+          _tirerr_state(tirerr_state) {}
+
+    VehicleState _veh_state;
+    TMeasyState _tirelf_state;
+    TMeasyState _tirerf_state;
+    TMeasyState _tirelr_state;
+    TMeasyState _tirerr_state;
+};
+
+struct SimStateNr {
+    SimStateNr() {}
+
+    SimStateNr(VehicleState veh_state,
+               TMeasyNrState tirelf_state,
+               TMeasyNrState tirerf_state,
+               TMeasyNrState tirelr_state,
+               TMeasyNrState tirerr_state)
+        : _veh_state(veh_state),
+          _tirelf_state(tirelf_state),
+          _tirerf_state(tirerf_state),
+          _tirelr_state(tirelr_state),
+          _tirerr_state(tirerr_state) {}
+
+    VehicleState _veh_state;
+    TMeasyNrState _tirelf_state;
+    TMeasyNrState _tirerf_state;
+    TMeasyNrState _tirelr_state;
+    TMeasyNrState _tirerr_state;
 };
 
 // ------------------------------------------------------------------------------

--- a/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cu
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cu
@@ -11,7 +11,7 @@
 
 using namespace d18;
 // ======================================================================================================================
-d18SolverHalfImplicitGPU::d18SolverHalfImplicitGPU(unsigned int total_num_vehicles)
+__host__ d18SolverHalfImplicitGPU::d18SolverHalfImplicitGPU(unsigned int total_num_vehicles)
     : m_step(0.001),
       m_output(false),
       m_vehicle_count_tracker_params(0),
@@ -32,7 +32,7 @@ d18SolverHalfImplicitGPU::d18SolverHalfImplicitGPU(unsigned int total_num_vehicl
     m_device_response = nullptr;
     m_host_response = nullptr;
 }
-d18SolverHalfImplicitGPU::~d18SolverHalfImplicitGPU() {
+__host__ d18SolverHalfImplicitGPU::~d18SolverHalfImplicitGPU() {
     // Only need to delete the memory of the simData and simStates of the respective tire as the rest of the memory is
     // freed as soon as we have information of what tire the user is using
     if (m_tire_type == TireType::TMeasy) {
@@ -89,8 +89,8 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
         m_sim_data[i]._veh_param = veh_param;
         m_sim_data[i]._tireTM_param = tire_param;
     }
-    cudaMemPrefetchAsync(&m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
-                         0);  // move the simData onto the GPU
+    CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
+                                          0));  // move the simData onto the GPU
 }
 
 __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_params_file,
@@ -138,8 +138,8 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
             m_sim_data[i]._veh_param = veh_param;
             m_sim_data[i]._tireTM_param = tire_param;
         }
-        cudaMemPrefetchAsync(&m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
-                             0);  // move the simData onto the GPU
+        CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
+                                              0));  // move the simData onto the GPU
     } else {
         // Because of this, we free the memory of the TMeasyNR tire
         cudaFree(m_sim_data);
@@ -173,11 +173,9 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
             // Fill up simulation data from the cpu structs
             m_sim_data_nr[i]._veh_param = veh_param;
             m_sim_data_nr[i]._tireTMNr_param = tire_param;
-            // Set the final integration time for each of the vehicles
-            m_sim_data_nr[i]._t_end = driver_data.back().m_time;
         }
-        cudaMemPrefetchAsync(&m_sim_data_nr, sizeof(SimData) * m_vehicle_count_tracker_params,
-                             0);  // move the simData onto the GPU
+        CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data_nr, sizeof(SimData) * m_vehicle_count_tracker_params,
+                                              0));  // move the simData onto the GPU
     }
 }
 
@@ -215,8 +213,8 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
         m_sim_data[i]._tireTM_param = tire_param;
     }
 
-    cudaMemPrefetchAsync(&m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
-                         0);  // move the simData onto the GPU
+    CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
+                                          0));  // move the simData onto the GPU
 }
 
 __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_params_file,
@@ -253,8 +251,8 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
             m_sim_data[i]._veh_param = veh_param;
             m_sim_data[i]._tireTM_param = tire_param;
         }
-        cudaMemPrefetchAsync(&m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
-                             0);  // move the simData onto the GPU
+        CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
+                                              0));  // move the simData onto the GPU
     } else {
         // Because of this, we free the memory of the TMeasyNR tire
         cudaFree(m_sim_data);
@@ -280,8 +278,8 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
             m_sim_data_nr[i]._veh_param = veh_param;
             m_sim_data_nr[i]._tireTMNr_param = tire_param;
         }
-        cudaMemPrefetchAsync(&m_sim_data_nr, sizeof(SimData) * m_vehicle_count_tracker_params,
-                             0);  // move the simData onto the GPU
+        CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data_nr, sizeof(SimData) * m_vehicle_count_tracker_params,
+                                              0));  // move the simData onto the GPU
     }
 }
 // ======================================================================================================================
@@ -295,7 +293,8 @@ __host__ void d18SolverHalfImplicitGPU::Initialize(d18::VehicleState& vehicle_st
     // Esnure that construct was called with TMeasy tire type
     assert((m_tire_type == TireType::TMeasy) &&
            "Construct function called with TMeasyNr tire type, but Initialize called with TMeasy tire type");
-
+    assert((num_vehicles + m_vehicle_count_tracker_states <= m_total_num_vehicles) &&
+           "Number of vehicles added makes the vehicle count greater than the total number of vehicles");
     size_t old_vehicle_count = m_vehicle_count_tracker_states;
     m_vehicle_count_tracker_states += num_vehicles;
     for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_states; i++) {
@@ -306,21 +305,8 @@ __host__ void d18SolverHalfImplicitGPU::Initialize(d18::VehicleState& vehicle_st
         m_sim_states[i]._tirelr_state = tire_states_LR;
         m_sim_states[i]._tirerr_state = tire_states_RR;
     }
-    cudaMemPrefetchAsync(&m_sim_states, sizeof(SimState) * m_vehicle_count_tracker_states,
-                         0);  // move the simState onto the GPU
-
-    // TODO: Add Jacobian support
-    // // Size the jacobian matrices - size relies on the torque converter bool
-    // m_num_controls = 2;
-    // if (m_veh_param._tcbool) {
-    //     m_num_states = 21;
-    //     m_jacobian_state.resize(m_num_states, std::vector<double>(m_num_states, 0));
-    //     m_jacobian_controls.resize(m_num_states, std::vector<double>(m_num_controls, 0));
-    // } else {
-    //     m_num_states = 20;
-    //     m_jacobian_state.resize(m_num_states, std::vector<double>(m_num_states, 0));
-    //     m_jacobian_controls.resize(m_num_states, std::vector<double>(m_num_controls, 0));
-    // }
+    CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_states, sizeof(SimState) * m_vehicle_count_tracker_states,
+                                          0));  // move the simState onto the GPU
 }
 
 // TMeasy without relaxation does not have tire states and so the jacobian size reduces by 8
@@ -333,6 +319,8 @@ __host__ void d18SolverHalfImplicitGPU::Initialize(d18::VehicleState& vehicle_st
     // Esnure that construct was called with TMeasyNr tire type
     assert((m_tire_type == TireType::TMeasyNr) &&
            "Construct function called with TMeasy tire type, but Initialize called with TMeasyNR tire type");
+    assert((num_vehicles + m_vehicle_count_tracker_states <= m_total_num_vehicles) &&
+           "Number of vehicles added makes the vehicle count greater than the total number of vehicles");
     size_t old_vehicle_count = m_vehicle_count_tracker_states;
     m_vehicle_count_tracker_states += num_vehicles;
     for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_states; i++) {
@@ -343,28 +331,15 @@ __host__ void d18SolverHalfImplicitGPU::Initialize(d18::VehicleState& vehicle_st
         m_sim_states_nr[i]._tirelr_state = tire_states_LR;
         m_sim_states_nr[i]._tirerr_state = tire_states_RR;
     }
-    cudaMemPrefetchAsync(&m_sim_states_nr, sizeof(SimState) * m_vehicle_count_tracker_states,
-                         0);  // move the simState onto the GPU
-
-    // TODO: Add Jacobian support
-    // Size the jacobian matrices - size relies on the torque converter bool
-    // m_num_controls = 2;
-    // if (m_veh_param._tcbool) {
-    //     m_num_states = 13;
-    //     m_jacobian_state.resize(m_num_states, std::vector<double>(m_num_states, 0));
-    //     m_jacobian_controls.resize(m_num_states, std::vector<double>(m_num_controls, 0));
-    // } else {
-    //     m_num_states = 12;
-    //     m_jacobian_state.resize(m_num_states, std::vector<double>(m_num_states, 0));
-    //     m_jacobian_controls.resize(m_num_states, std::vector<double>(m_num_controls, 0));
-    // }
+    CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_states_nr, sizeof(SimState) * m_vehicle_count_tracker_states,
+                                          0));  // move the simState onto the GPU
 }
 
 // ======================================================================================================================
 __host__ void d18SolverHalfImplicitGPU::SetOutput(const std::string& output_file,
                                                   double output_freq,
-                                                  bool store_all = false,
-                                                  unsigned int no_outs = 50) {
+                                                  bool store_all,
+                                                  unsigned int no_outs) {
     m_output = true;
     m_store_all = store_all;
     if (!m_store_all) {
@@ -380,6 +355,8 @@ __host__ void d18SolverHalfImplicitGPU::SetOutput(const std::string& output_file
         for (std::size_t i = 0; i < no_outs; i++) {
             m_which_outs[i] = dist_input(generator);
         }
+    } else {
+        m_num_outs = m_total_num_vehicles;
     }
     m_output_file = output_file;
     m_dtout = 1.0 / output_freq;
@@ -404,30 +381,47 @@ __host__ void d18SolverHalfImplicitGPU::SetOutput(const std::string& output_file
     m_host_collection_timeSteps = ceil(m_host_dump_time / m_dtout);
 
     // Thus the host size becomes -> Usually much larger than the device size
-    m_host_response = new double[m_total_num_vehicles * m_collection_states * (m_host_collection_timeSteps)];
+    m_host_response = new double[m_total_num_vehicles * m_collection_states * (m_host_collection_timeSteps)]();
 }
 
 // ======================================================================================================================
 
 /// @brief Solve the system of equations by calling the integrate function
 __host__ void d18SolverHalfImplicitGPU::Solve() {
-    assert(!m_driver_data.empty() && "No controls provided, please use construct to pass path to driver inputs");
     assert(m_tend != 0. && "Final time not set, please use SetEndTime function");
     // Calculate the number of blocks required
     m_num_blocks = (m_total_num_vehicles + m_threads_per_block - 1) / m_threads_per_block;
+    std::cout << "Number of blocks: " << m_num_blocks << std::endl;
+    std::cout << "Number of threads per block: " << m_threads_per_block << std::endl;
+    std::cout << "Total number of vehicles: " << m_total_num_vehicles << std::endl;
 
     double current_time = 0.;
     unsigned int kernel_launches_since_last_dump = 0;  // Track the number of kernel launches since the last dump of the
                                                        // host response
     double time_since_last_dump = 0.;                  // Track the time since the last dump of the host response
-
     while (current_time < m_tend) {
         // Calculate when this kernel is supposed to end
 
         double kernel_end_time = current_time + m_kernel_sim_time;
 
         // Launch the kernel
-        Integrate<<<m_num_blocks, m_threads_per_block>>>(current_time);
+        if (m_tire_type == TireType::TMeasy) {
+            Integrate<<<m_num_blocks, m_threads_per_block>>>(current_time, m_kernel_sim_time, m_step, m_output,
+                                                             m_total_num_vehicles, m_collection_states, m_dtout,
+                                                             m_device_response, m_sim_data, m_sim_states);
+            cudaError_t err = cudaGetLastError();
+            if (err != cudaSuccess) {
+                fprintf(stderr, "Kernel launch failed: %s\n", cudaGetErrorString(err));
+            }
+        } else {
+            Integrate<<<m_num_blocks, m_threads_per_block>>>(current_time, m_kernel_sim_time, m_step, m_output,
+                                                             m_total_num_vehicles, m_collection_states, m_dtout,
+                                                             m_device_response, m_sim_data_nr, m_sim_states_nr);
+            cudaError_t err = cudaGetLastError();
+            if (err != cudaSuccess) {
+                fprintf(stderr, "Kernel launch failed: %s\n", cudaGetErrorString(err));
+            }
+        }
 
         // Get the new time the simulation has reached
         current_time = kernel_end_time;
@@ -457,670 +451,6 @@ __host__ void d18SolverHalfImplicitGPU::Solve() {
     // End of simulation, write to the csv file
     if (m_output) {
         WriteToFile();
-    }
-}
-
-// ======================================================================================================================
-
-/// @brief Integrate the system of equations using the half implicit method - Calls the RHS function at each time step
-__device__ void d18SolverHalfImplicitGPU::Integrate(double current_time) {
-    double t = current_time;           // Set the current time
-    double kernel_time = 0;            // Time since kernel was launched
-    unsigned int timeStep_stored = 0;  // Number of time steps already stored in the device response
-
-    unsigned int vehicle_id = blockIdx.x * blockDim.x + threadIdx.x;  // Get the vehicle id
-    while (t < ((t + m_kernel_sim_time) - m_step / 10.)) {
-        // Call the RHS to get accelerations for all the vehicles
-        rhsFun(t);
-
-        // Integrate according to half implicit method for second order states
-        // Integrate according to explicit method for first order states
-
-        if (m_tire_type == TireType::TMeasy) {
-            // Extract the states of the vehicle and the tires
-            VehicleState& v_states = m_sim_states[vehicle_id]._veh_state;
-            VehicleParam& veh_param = m_sim_data[vehicle_id]._veh_param;
-            TMeasyState& tirelf_st = m_sim_states[vehicle_id]._tirelf_state;
-            TMeasyState& tirerf_st = m_sim_states[vehicle_id]._tirerf_state;
-            TMeasyState& tirelr_st = m_sim_states[vehicle_id]._tirelr_state;
-            TMeasyState& tirerr_st = m_sim_states[vehicle_id]._tirerr_state;
-
-            // First the tire states
-            // LF
-            tirelf_st._xe += tirelf_st._xedot * m_step;
-            tirelf_st._ye += tirelf_st._yedot * m_step;
-            tirelf_st._omega += tirelf_st._dOmega * m_step;
-            // RF
-            tirerf_st._xe += tirerf_st._xedot * m_step;
-            tirerf_st._ye += tirerf_st._yedot * m_step;
-            tirerf_st._omega += tirerf_st._dOmega * m_step;
-            // LR
-            tirelr_st._xe += tirelr_st._xedot * m_step;
-            tirelr_st._ye += tirelr_st._yedot * m_step;
-            tirelr_st._omega += tirelr_st._dOmega * m_step;
-            // RR
-            tirerr_st._xe += tirerr_st._xedot * m_step;
-            tirerr_st._ye += tirerr_st._yedot * m_step;
-            tirerr_st._omega += tirerr_st._dOmega * m_step;
-
-            // Now the vehicle states
-            if (veh_param._tcbool) {
-                v_states._crankOmega += v_states._dOmega_crank * m_step;
-            }
-
-            // Integrate velocity level first
-            v_states._u += v_states._udot * m_step;
-            v_states._v += v_states._vdot * m_step;
-            v_states._wx += v_states._wxdot * m_step;
-            v_states._wz += v_states._wzdot * m_step;
-
-            // Integrate position level next
-            v_states._x += (v_states._u * cos(v_states._psi) - v_states._v * sin(v_states._psi)) * m_step;
-            v_states._y += (v_states._u * sin(v_states._psi) + v_states._v * cos(v_states._psi)) * m_step;
-            v_states._psi += v_states._wz * m_step;
-            v_states._phi += v_states._wx * m_step;
-
-            // Update time
-            t += m_step;
-            kernel_time += m_step;
-
-            // Write to response if required -> regardless of no_outs or store_all we write all the vehicles to the
-            // response
-            if (m_output) {
-                if (abs(kernel_time - timeStep_stored * m_dtout) < 1e-7) {
-                    unsigned int time_offset = timeStep_stored * m_total_num_vehicles * m_collection_states;
-
-                    m_device_response[time_offset + (m_total_num_vehicles * 0) + vehicle_id] = t;
-                    m_device_response[time_offset + (m_total_num_vehicles * 1) + vehicle_id] = v_states._x;
-                    m_device_response[time_offset + (m_total_num_vehicles * 2) + vehicle_id] = v_states._y;
-                    m_device_response[time_offset + (m_total_num_vehicles * 3) + vehicle_id] = v_states._u;
-                    m_device_response[time_offset + (m_total_num_vehicles * 4) + vehicle_id] = v_states._v;
-                    m_device_response[time_offset + (m_total_num_vehicles * 5) + vehicle_id] = v_states._phi;
-                    m_device_response[time_offset + (m_total_num_vehicles * 6) + vehicle_id] = v_states._psi;
-                    m_device_response[time_offset + (m_total_num_vehicles * 7) + vehicle_id] = v_states._wx;
-                    m_device_response[time_offset + (m_total_num_vehicles * 8) + vehicle_id] = v_states._wz;
-                    m_device_response[time_offset + (m_total_num_vehicles * 9) + vehicle_id] = tirelf_st._omega;
-                    m_device_response[time_offset + (m_total_num_vehicles * 10) + vehicle_id] = tirerf_st._omega;
-                    m_device_response[time_offset + (m_total_num_vehicles * 11) + vehicle_id] = tirelr_st._omega;
-                    m_device_response[time_offset + (m_total_num_vehicles * 12) + vehicle_id] = tirerr_st._omega;
-                }
-            }
-
-        } else {
-            // Extract the states of the vehicle and the tires
-            VehicleState& v_states = m_sim_states_nr[vehicle_id]._veh_state;
-            VehicleParam& veh_param = m_sim_data_nr[vehicle_id]._veh_param;
-            TMeasyNrState& tirelf_st = m_sim_states_nr[vehicle_id]._tirelf_state;
-            TMeasyNrState& tirerf_st = m_sim_states_nr[vehicle_id]._tirerf_state;
-            TMeasyNrState& tirelr_st = m_sim_states_nr[vehicle_id]._tirelr_state;
-            TMeasyNrState& tirerr_st = m_sim_states_nr[vehicle_id]._tirerr_state;
-
-            // First the tire states
-            // LF
-            tirelf_st._omega += tirelf_st._dOmega * m_step;
-            // RF
-            tirerf_st._omega += tirerf_st._dOmega * m_step;
-            // LR
-            tirelr_st._omega += tirelr_st._dOmega * m_step;
-            // RR
-            tirerr_st._omega += tirerr_st._dOmega * m_step;
-
-            // Now the vehicle states
-            if (veh_param._tcbool) {
-                v_states._crankOmega += v_states._dOmega_crank * m_step;
-            }
-
-            // Integrate velocity level first
-            v_states._u += v_states._udot * m_step;
-            v_states._v += v_states._vdot * m_step;
-            v_states._wx += v_states._wxdot * m_step;
-            v_states._wz += v_states._wzdot * m_step;
-            // Integrate position level next
-            v_states._x += (v_states._u * cos(v_states._psi) - v_states._v * sin(v_states._psi)) * m_step;
-            v_states._y += (v_states._u * sin(v_states._psi) + v_states._v * cos(v_states._psi)) * m_step;
-            v_states._psi += v_states._wz * m_step;
-            v_states._phi += v_states._wx * m_step;
-
-            // Update time
-            t += m_step;
-            kernel_time += m_step;
-
-            // Write to response if required -> regardless of no_outs or store_all we write all the vehicles to the
-            // response
-            if (m_output) {
-                if (abs(kernel_time - timeStep_stored * m_dtout) < 1e-7) {
-                    unsigned int time_offset = timeStep_stored * m_total_num_vehicles * m_collection_states;
-
-                    m_device_response[time_offset + (m_total_num_vehicles * 0) + vehicle_id] = t;
-                    m_device_response[time_offset + (m_total_num_vehicles * 1) + vehicle_id] = v_states._x;
-                    m_device_response[time_offset + (m_total_num_vehicles * 2) + vehicle_id] = v_states._y;
-                    m_device_response[time_offset + (m_total_num_vehicles * 3) + vehicle_id] = v_states._u;
-                    m_device_response[time_offset + (m_total_num_vehicles * 4) + vehicle_id] = v_states._v;
-                    m_device_response[time_offset + (m_total_num_vehicles * 5) + vehicle_id] = v_states._phi;
-                    m_device_response[time_offset + (m_total_num_vehicles * 6) + vehicle_id] = v_states._psi;
-                    m_device_response[time_offset + (m_total_num_vehicles * 7) + vehicle_id] = v_states._wx;
-                    m_device_response[time_offset + (m_total_num_vehicles * 8) + vehicle_id] = v_states._wz;
-                    m_device_response[time_offset + (m_total_num_vehicles * 9) + vehicle_id] = tirelf_st._omega;
-                    m_device_response[time_offset + (m_total_num_vehicles * 10) + vehicle_id] = tirerf_st._omega;
-                    m_device_response[time_offset + (m_total_num_vehicles * 11) + vehicle_id] = tirelr_st._omega;
-                    m_device_response[time_offset + (m_total_num_vehicles * 12) + vehicle_id] = tirerr_st._omega;
-                }
-            }
-        }
-    }
-}
-// ======================================================================================================================
-
-/// @brief Function call to integrate by just a single time step. This function will always integrate to the t + m_step
-/// where m_step is set using the SetTimeStep function.
-/// @param t current time
-/// @param throttle throttle input
-/// @param steering steering input
-/// @param braking braking input
-/// @return t + m_step
-double d18SolverHalfImplicitGPU::IntegrateStep(double t, double throttle, double steering, double braking) {
-    // Store header and first time step
-    if (m_output && (t < m_step)) {
-        Write(t);
-        m_timeStepsStored++;
-    }
-
-    DriverInput controls(t, steering, throttle, braking);
-    // Call the RHS function
-    rhsFun(t, controls);
-
-    // Integrate according to half implicit method for second order states
-    // Integrate according to explicit method for first order states
-
-    if (m_tire_type == TireType::TMeasy) {  // Only TM easy has xe and ye states
-        // First the tire states
-        // LF
-        m_tireTMlf_state._xe += m_tireTMlf_state._xedot * m_step;
-        m_tireTMlf_state._ye += m_tireTMlf_state._yedot * m_step;
-        m_tireTMlf_state._omega += m_tireTMlf_state._dOmega * m_step;
-        // RF
-        m_tireTMrf_state._xe += m_tireTMrf_state._xedot * m_step;
-        m_tireTMrf_state._ye += m_tireTMrf_state._yedot * m_step;
-        m_tireTMrf_state._omega += m_tireTMrf_state._dOmega * m_step;
-        // LR
-        m_tireTMlr_state._xe += m_tireTMlr_state._xedot * m_step;
-        m_tireTMlr_state._ye += m_tireTMlr_state._yedot * m_step;
-        m_tireTMlr_state._omega += m_tireTMlr_state._dOmega * m_step;
-        // RR
-        m_tireTMrr_state._xe += m_tireTMrr_state._xedot * m_step;
-        m_tireTMrr_state._ye += m_tireTMrr_state._yedot * m_step;
-        m_tireTMrr_state._omega += m_tireTMrr_state._dOmega * m_step;
-    } else {  // Other tires have only omega states
-        // First the tire states
-        // LF
-        m_tireTMNrlf_state._omega += m_tireTMNrlf_state._dOmega * m_step;
-        // RF
-        m_tireTMNrrf_state._omega += m_tireTMNrrf_state._dOmega * m_step;
-        // LR
-        m_tireTMNrlr_state._omega += m_tireTMNrlr_state._dOmega * m_step;
-        // RR
-        m_tireTMNrrr_state._omega += m_tireTMNrrr_state._dOmega * m_step;
-    }
-
-    // Now the vehicle states
-    if (m_veh_param._tcbool) {
-        m_veh_state._crankOmega += m_veh_state._dOmega_crank * m_step;
-    }
-
-    // Integrate velocity level first
-    m_veh_state._u += m_veh_state._udot * m_step;
-    m_veh_state._v += m_veh_state._vdot * m_step;
-    m_veh_state._wx += m_veh_state._wxdot * m_step;
-    m_veh_state._wz += m_veh_state._wzdot * m_step;
-
-    // Integrate position level next
-    m_veh_state._x +=
-        (m_veh_state._u * std::cos(m_veh_state._psi) - m_veh_state._v * std::sin(m_veh_state._psi)) * m_step;
-    m_veh_state._y +=
-        (m_veh_state._u * std::sin(m_veh_state._psi) + m_veh_state._v * std::cos(m_veh_state._psi)) * m_step;
-    m_veh_state._psi += m_veh_state._wz * m_step;
-    m_veh_state._phi += m_veh_state._wx * m_step;
-
-    double new_time = t + m_step;
-    // Write the output
-    if (m_output) {
-        if (std::abs(new_time - m_timeStepsStored * m_dtout) < 1e-7) {
-            Write(new_time);
-            m_timeStepsStored++;
-        }
-    }
-
-    return new_time;
-}
-// ======================================================================================================================
-/// @brief Function call to integrate by just a single time step with jacobian computation. The order of the states in
-// the jacobian matrix if the TMeasy tire is used are is as follows:
-//  0: tirelf_st._xe;
-//  1: tirelf_st._ye;
-//  2: tirerf_st._xe;
-//  3: tirerf_st._ye;
-//  4: tirelr_st._xe;
-//  5: tirelr_st._ye;
-//  6: tirerr_st._xe;
-//  7: tirerr_st._ye;
-//  8: tirelf_st._omega;
-//  9: tirerf_st._omega;
-//  10: tirelr_st._omega;
-//  11: tirerr_st._omega;
-//  12: v_states._crankOmega; (only if torque converter is used)
-//  13: v_states._x;
-//  14: v_states._y;
-//  15: v_states._u;
-//  16: v_states._v;
-//  17: v_states._psi;
-//  18: v_states._wz;
-//  19: v_states._phi;
-//  20: v_states._wx;
-// If the TMeasyNR tire is used then the order of the states in the jacobian matrix are as follows:
-//  0: tirelf_st._omega;
-//  1: tirerf_st._omega;
-//  2: tirelr_st._omega;
-//  3: tirerr_st._omega;
-//  4: v_states._crankOmega; (only if torque converter is used)
-//  5: v_states._x;
-//  6: v_states._y;
-//  7: v_states._u;
-//  8: v_states._v;
-//  9: v_states._psi;
-//  10: v_states._wz;
-//  11: v_states._phi;
-//  12: v_states._wx;
-/// @param t current time
-/// @param throttle throttle input
-/// @param steering steering input
-/// @param braking braking input
-/// @param on boolean to turn on jacobian computation
-/// @return t + m_step
-double d18SolverHalfImplicitGPU::IntegrateStepWithJacobian(double t,
-                                                           double throttle,
-                                                           double steering,
-                                                           double braking,
-                                                           bool jacOn) {
-    // Store header and first time step
-    if (m_output && (t < m_step)) {
-        Write(t);
-        m_timeStepsStored++;
-    }
-
-    DriverInput controls(t, steering, throttle, braking);
-
-    // If the jacobian switch is on, then compute the jacobian
-    if (jacOn) {
-        std::vector<double> y(m_num_states, 0);
-        std::vector<double> ydot(m_num_states, 0);
-        // package all the current states
-        if (m_tire_type == TireType::TMeasy) {
-            packY(m_veh_state, m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state,
-                  m_veh_param._tcbool, y);
-        } else {
-            packY(m_veh_state, m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state, m_tireTMNrrr_state,
-                  m_veh_param._tcbool, y);
-        }
-
-        // ============================
-        // Computing the state jacobian
-        // ============================
-
-        // Set a vector of del Ys - for now set this to some scale of y
-        std::vector<double> delY(y.begin(), y.end());
-        // In a loop pertub each state and get the corresponding perturbed ydot
-        int ySize = y.size();
-
-#pragma omp parallel for simd
-        for (int i = 0; i < ySize; i++) {
-            // Perterbation is 1e-3 * y (since some states are really small values wile some are huge)
-            delY[i] = std::abs(delY[i] * 1e-3);
-            if (delY[i] < 1e-8) {
-                // This means that the particular state is 0. In this case set dels to 1e-3
-                delY[i] = 1e-3;
-            }
-
-            // perturb y at i
-            std::vector<double> perturbedYPlus(y.begin(), y.end());
-            std::vector<double> perturbedYMinus(y.begin(), y.end());
-
-            perturbedYPlus[i] = perturbedYPlus[i] + delY[i];
-            perturbedYMinus[i] = perturbedYMinus[i] - delY[i];
-
-            // ydots to store the output
-            std::vector<double> ydotPlus(y.size(), 0.);
-            std::vector<double> ydotMinus(y.size(), 0.);
-
-            // Call the perturb function with these to get the perturbed ydot -> This does not update the state
-            PerturbRhsFun(perturbedYPlus, controls, ydotPlus);
-            PerturbRhsFun(perturbedYMinus, controls, ydotMinus);
-
-// Update the jacobian matrix
-#pragma omp simd
-            for (int j = 0; j < ySize; j++) {
-                m_jacobian_state[j][i] = (ydotPlus[j] - ydotMinus[j]) / (2 * delY[i]);
-            }
-        }
-
-        // ==============================
-        // Computing the control jacobian
-        //===============================
-
-        // Set a vector of del controls - for now we ingnore braking
-        std::vector<double> delControls = {1e-3, 1e-3};
-        // In a loop pertub each control and get the corresponding perturbed ydot
-        int controlSize = delControls.size();
-
-        for (int i = 0; i < controlSize; i++) {
-            // perturb controls at i
-            std::vector<double> perturbedControlsPlus = {steering, throttle};
-            std::vector<double> perturbedControlsMinus = {steering, throttle};
-
-            perturbedControlsPlus[i] = perturbedControlsPlus[i] + delControls[i];
-            perturbedControlsMinus[i] = perturbedControlsMinus[i] - delControls[i];
-
-            // ydots to store the output
-            std::vector<double> ydotPlus(y.size(), 0.);
-            std::vector<double> ydotMinus(y.size(), 0.);
-
-            // Call the perturb function with these to get the perturbed ydot -> This does not update the state
-            DriverInput inputPlus(t, perturbedControlsPlus[0], perturbedControlsPlus[1], 0);
-            DriverInput inputMinus(t, perturbedControlsMinus[0], perturbedControlsMinus[1], 0);
-            PerturbRhsFun(y, inputPlus, ydotPlus);
-            PerturbRhsFun(y, inputMinus, ydotMinus);
-
-            // Update the jacobian matrix
-            for (int j = 0; j < ySize; j++) {
-                m_jacobian_controls[j][i] = (ydotPlus[j] - ydotMinus[j]) / (2 * delControls[i]);
-            }
-        }
-    }
-
-    // Call the RHS function
-    rhsFun(t, controls);
-
-    // Integrate according to half implicit method for second order states
-    // Integrate according to explicit method for first order states
-
-    if (m_tire_type == TireType::TMeasy) {  // Only TM easy has xe and ye states
-        // First the tire states
-        // LF
-        m_tireTMlf_state._xe += m_tireTMlf_state._xedot * m_step;
-        m_tireTMlf_state._ye += m_tireTMlf_state._yedot * m_step;
-        m_tireTMlf_state._omega += m_tireTMlf_state._dOmega * m_step;
-        // RF
-        m_tireTMrf_state._xe += m_tireTMrf_state._xedot * m_step;
-        m_tireTMrf_state._ye += m_tireTMrf_state._yedot * m_step;
-        m_tireTMrf_state._omega += m_tireTMrf_state._dOmega * m_step;
-        // LR
-        m_tireTMlr_state._xe += m_tireTMlr_state._xedot * m_step;
-        m_tireTMlr_state._ye += m_tireTMlr_state._yedot * m_step;
-        m_tireTMlr_state._omega += m_tireTMlr_state._dOmega * m_step;
-        // RR
-        m_tireTMrr_state._xe += m_tireTMrr_state._xedot * m_step;
-        m_tireTMrr_state._ye += m_tireTMrr_state._yedot * m_step;
-        m_tireTMrr_state._omega += m_tireTMrr_state._dOmega * m_step;
-    } else {  // Other tires have only omega states
-        // First the tire states
-        // LF
-        m_tireTMNrlf_state._omega += m_tireTMNrlf_state._dOmega * m_step;
-        // RF
-        m_tireTMNrrf_state._omega += m_tireTMNrrf_state._dOmega * m_step;
-        // LR
-        m_tireTMNrlr_state._omega += m_tireTMNrlr_state._dOmega * m_step;
-        // RR
-        m_tireTMNrrr_state._omega += m_tireTMNrrr_state._dOmega * m_step;
-    }
-    // Now the vehicle states
-    if (m_veh_param._tcbool) {
-        m_veh_state._crankOmega += m_veh_state._dOmega_crank * m_step;
-    }
-
-    // Integrate velocity level first
-    m_veh_state._u += m_veh_state._udot * m_step;
-    m_veh_state._v += m_veh_state._vdot * m_step;
-    m_veh_state._wx += m_veh_state._wxdot * m_step;
-    m_veh_state._wz += m_veh_state._wzdot * m_step;
-
-    // Integrate position level next
-    m_veh_state._x +=
-        (m_veh_state._u * std::cos(m_veh_state._psi) - m_veh_state._v * std::sin(m_veh_state._psi)) * m_step;
-    m_veh_state._y +=
-        (m_veh_state._u * std::sin(m_veh_state._psi) + m_veh_state._v * std::cos(m_veh_state._psi)) * m_step;
-    m_veh_state._psi += m_veh_state._wz * m_step;
-    m_veh_state._phi += m_veh_state._wx * m_step;
-
-    double new_time = t + m_step;
-    // Write the output
-    if (m_output) {
-        if (std::abs(new_time - m_timeStepsStored * m_dtout) < 1e-7) {
-            Write(new_time);
-            m_timeStepsStored++;
-        }
-    }
-
-    return new_time;
-}
-
-// ======================================================================================================================
-
-/// @brief Computes the RHS of all the ODEs (tire velocities, chassis accelerations)
-/// @param t Current time
-__device__ void d18SolverHalfImplicitGPU::rhsFun(double t) {
-    // Get the vehicle index
-    unsigned int vehicle_index = blockIdx.x * blockDim.x + threadIdx.x;
-
-    if (vehicle_index < m_total_num_vehicles) {
-        // All vehicles have one or the other tire type and thus no thread divergence
-        if (m_tire_type == TireType::TMeasy) {
-            VehicleParam& veh_param = m_sim_data[vehicle_index]._veh_param;
-            VehicleState& veh_state = m_sim_states[vehicle_index]._veh_state;
-            TMeasyParam& tireTM_param = m_sim_data[vehicle_index]._tireTM_param;
-            TMeasyState& tireTMlf_state = m_sim_states[vehicle_index]._tirelf_state;
-            TMeasyState& tireTMrf_state = m_sim_states[vehicle_index]._tirerf_state;
-            TMeasyState& tireTMlr_state = m_sim_states[vehicle_index]._tirelr_state;
-            TMeasyState& tireTMrr_state = m_sim_states[vehicle_index]._tirerr_state;
-
-            DriverInput* driver_data = m_sim_data[vehicle_index]._driver_data;
-            unsigned int len = m_sim_data[vehicle_index]._driver_data_len;
-            // Get controls at the current timeStep
-            auto controls = GetDriverInput(t, driver_data, len);
-
-            double loads[4] = {0., 0., 0., 0.};
-            // Compute the tire loads
-            computeTireLoads(&loads[0], &veh_state, &veh_param, &tireTM_param);
-            // Transform from vehicle frame to the tire frame
-            vehToTireTransform(&tireTMlf_state, &tireTMrf_state, &tireTMlr_state, &tireTMrr_state, &veh_state,
-                               &loads[0], &veh_param, controls.m_steering);
-
-            // Tire velocities using TMEasy tire
-            computeTireRHS(&tireTMlf_state, &tireTM_param, &veh_param, controls.m_steering);
-            computeTireRHS(&tireTMrf_state, &tireTM_param, &veh_param, controls.m_steering);
-            computeTireRHS(&tireTMlr_state, &tireTM_param, &veh_param, 0);  // No rear steering
-            computeTireRHS(&tireTMrr_state, &tireTM_param, &veh_param, 0);  // No rear steering
-
-            // Powertrain dynamics
-            computePowertrainRHS(&veh_state, &tireTMlf_state, &tireTMrf_state, &tireTMlr_state, &tireTMrr_state,
-                                 &veh_param, &tireTM_param, &controls);
-            // Vehicle dynamics
-            tireToVehTransform(&tireTMlf_state, &tireTMrf_state, &tireTMlr_state, &tireTMrr_state, &veh_state,
-                               &veh_param, controls.m_steering);
-
-            double fx[4] = {tireTMlf_state._fx, tireTMrf_state._fx, tireTMlr_state._fx, tireTMrr_state._fx};
-            double fy[4] = {tireTMlf_state._fy, tireTMrf_state._fy, tireTMlr_state._fy, tireTMrr_state._fy};
-
-            computeVehRHS(&veh_state, &veh_param, &fx[0], &fy[0]);
-
-        } else {
-            VehicleParam& veh_param = m_sim_data_nr[vehicle_index]._veh_param;
-            VehicleState& veh_state = m_sim_states_nr[vehicle_index]._veh_state;
-            TMeasyNrParam& tireTMNr_param = m_sim_data_nr[vehicle_index]._tireTMNr_param;
-            TMeasyNrState& tireTMNrlf_state = m_sim_states_nr[vehicle_index]._tirelf_state;
-            TMeasyNrState& tireTMNrrf_state = m_sim_states_nr[vehicle_index]._tirerf_state;
-            TMeasyNrState& tireTMNrlr_state = m_sim_states_nr[vehicle_index]._tirelr_state;
-            TMeasyNrState& tireTMNrrr_state = m_sim_states_nr[vehicle_index]._tirerr_state;
-            DriverInput* driver_data = m_sim_data_nr[vehicle_index]._driver_data;
-            unsigned int len = m_sim_data_nr[vehicle_index]._driver_data_len;
-            // Get controls at the current timeStep
-            auto controls = GetDriverInput(t, driver_data, len);
-
-            double loads[4] = {0., 0., 0., 0.};
-
-            // Compute the tire loads
-            computeTireLoads(&loads[0], &veh_state, &veh_param, &tireTMNr_param);
-            // Transform from vehicle frame to the tire frame
-            vehToTireTransform(&tireTMNrlf_state, &tireTMNrrf_state, &tireTMNrlr_state, &tireTMNrrr_state, &veh_state,
-                               &loads[0], &veh_param, controls.m_steering);
-            // Tire velocities using TMEasyNr tire
-            computeTireRHS(&tireTMNrlf_state, &tireTMNr_param, &veh_param, controls.m_steering);
-            computeTireRHS(&tireTMNrrf_state, &tireTMNr_param, &veh_param, controls.m_steering);
-            computeTireRHS(&tireTMNrlr_state, &tireTMNr_param, &veh_param, 0);  // No rear steering
-            computeTireRHS(&tireTMNrrr_state, &tireTMNr_param, &veh_param, 0);  // No rear steering
-
-            // Powertrain dynamics
-            computePowertrainRHS(&veh_state, &tireTMNrlf_state, &tireTMNrrf_state, &tireTMNrlr_state, &tireTMNrrr_state,
-                                 &veh_param, &tireTMNr_param, &controls);
-
-            // Vehicle dynamics
-            tireToVehTransform(&tireTMNrlf_state, &tireTMNrrf_state, &tireTMNrlr_state, &tireTMNrrr_state, &veh_state,
-                               &veh_param, controls.m_steering);
-
-            double fx[4] = {tireTMNrlf_state._fx, tireTMNrrf_state._fx, tireTMNrlr_state._fx, tireTMNrrr_state._fx};
-            double fy[4] = {tireTMNrlf_state._fy, tireTMNrrf_state._fy, tireTMNrlr_state._fy, tireTMNrrr_state._fy};
-
-            computeVehRHS(&veh_state, &veh_param, &fx[0], &fy[0]);
-        }
-    }
-}
-
-// ======================================================================================================================
-
-void d18SolverHalfImplicitGPU::rhsFun(double t, DriverInput& controls) {
-    // Calculate tire vertical loads
-    std::vector<double> loads(4, 0);
-    if (m_tire_type == TireType::TMeasy) {
-        computeTireLoads(loads, m_veh_state, m_veh_param, m_tireTM_param);
-
-        // Transform from vehicle frame to the tire frame
-        vehToTireTransform(m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state, m_veh_state, loads,
-                           m_veh_param, controls.m_steering);
-
-        // Tire velocities using TMEasy tire
-        computeTireRHS(m_tireTMlf_state, m_tireTM_param, m_veh_param, controls.m_steering);
-        computeTireRHS(m_tireTMrf_state, m_tireTM_param, m_veh_param, controls.m_steering);
-        computeTireRHS(m_tireTMlr_state, m_tireTM_param, m_veh_param, 0);  // No rear steering
-        computeTireRHS(m_tireTMrr_state, m_tireTM_param, m_veh_param, 0);  // No rear steering
-
-        // Powertrain dynamics
-        computePowertrainRHS(m_veh_state, m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state,
-                             m_veh_param, m_tireTM_param, controls);
-
-        // Vehicle dynamics
-        tireToVehTransform(m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state, m_veh_state,
-                           m_veh_param, controls.m_steering);
-        std::vector<double> fx = {m_tireTMlf_state._fx, m_tireTMrf_state._fx, m_tireTMlr_state._fx,
-                                  m_tireTMrr_state._fx};
-        std::vector<double> fy = {m_tireTMlf_state._fy, m_tireTMrf_state._fy, m_tireTMlr_state._fy,
-                                  m_tireTMrr_state._fy};
-        computeVehRHS(m_veh_state, m_veh_param, fx, fy);
-    } else {  // For the other tire
-        computeTireLoads(loads, m_veh_state, m_veh_param, m_tireTMNr_param);
-
-        // Transform from vehicle frame to the tire frame
-        vehToTireTransform(m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state, m_tireTMNrrr_state, m_veh_state,
-                           loads, m_veh_param, controls.m_steering);
-
-        // Tire velocities using TMEasy tire
-        computeTireRHS(m_tireTMNrlf_state, m_tireTMNr_param, m_veh_param, controls.m_steering);
-        computeTireRHS(m_tireTMNrrf_state, m_tireTMNr_param, m_veh_param, controls.m_steering);
-        computeTireRHS(m_tireTMNrlr_state, m_tireTMNr_param, m_veh_param, 0);  // No rear steering
-        computeTireRHS(m_tireTMNrrr_state, m_tireTMNr_param, m_veh_param, 0);  // No rear steering
-
-        // Powertrain dynamics
-        computePowertrainRHS(m_veh_state, m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state,
-                             m_tireTMNrrr_state, m_veh_param, m_tireTMNr_param, controls);
-
-        // Vehicle dynamics
-        tireToVehTransform(m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state, m_tireTMNrrr_state, m_veh_state,
-                           m_veh_param, controls.m_steering);
-        std::vector<double> fx = {m_tireTMNrlf_state._fx, m_tireTMNrrf_state._fx, m_tireTMNrlr_state._fx,
-                                  m_tireTMNrrr_state._fx};
-        std::vector<double> fy = {m_tireTMNrlf_state._fy, m_tireTMNrrf_state._fy, m_tireTMNrlr_state._fy,
-                                  m_tireTMNrrr_state._fy};
-        computeVehRHS(m_veh_state, m_veh_param, fx, fy);
-    }
-}
-
-// ======================================================================================================================
-
-// Function takes (y +- dely) and provides a new ydot for the pertubed y (ydot is the rhs of the system of equations)
-
-void d18SolverHalfImplicitGPU::PerturbRhsFun(std::vector<double>& y, DriverInput& controls, std::vector<double>& ydot) {
-    // Extract the vehicle and tire states vector state
-    VehicleState veh_st;
-    if (m_tire_type == TireType::TMeasy) {
-        TMeasyState tirelf_st;
-        TMeasyState tirerf_st;
-        TMeasyState tirelr_st;
-        TMeasyState tirerr_st;
-        unpackY(y, m_veh_param._tcbool, veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st);
-
-        // Calculate tire vertical loads
-        std::vector<double> loads(4, 0);
-        computeTireLoads(loads, veh_st, m_veh_param, m_tireTM_param);
-
-        // Transform from the vehicle frame to the tire frame
-        vehToTireTransform(tirelf_st, tirerf_st, tirelr_st, tirerr_st, veh_st, loads, m_veh_param, controls.m_steering);
-
-        // Tire dynamics
-        computeTireRHS(tirelf_st, m_tireTM_param, m_veh_param, controls.m_steering);
-        computeTireRHS(tirerf_st, m_tireTM_param, m_veh_param, controls.m_steering);
-        computeTireRHS(tirelr_st, m_tireTM_param, m_veh_param, 0);
-        computeTireRHS(tirerr_st, m_tireTM_param, m_veh_param, 0);
-
-        // Powertrain dynamics
-        computePowertrainRHS(veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st, m_veh_param, m_tireTM_param, controls);
-
-        // Vehicle dynamics
-        tireToVehTransform(tirelf_st, tirerf_st, tirelr_st, tirerr_st, veh_st, m_veh_param, controls.m_steering);
-        std::vector<double> fx = {tirelf_st._fx, tirerf_st._fx, tirelr_st._fx, tirerr_st._fx};
-        std::vector<double> fy = {tirelf_st._fy, tirerf_st._fy, tirelr_st._fy, tirerr_st._fy};
-        computeVehRHS(veh_st, m_veh_param, fx, fy);
-
-        // Pack the ydot and send it
-        packYDOT(veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st, m_veh_param._tcbool, ydot);
-    } else {
-        TMeasyNrState tirelf_st;
-        TMeasyNrState tirerf_st;
-        TMeasyNrState tirelr_st;
-        TMeasyNrState tirerr_st;
-        unpackY(y, m_veh_param._tcbool, veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st);
-
-        // Calculate tire vertical loads
-        std::vector<double> loads(4, 0);
-        computeTireLoads(loads, veh_st, m_veh_param, m_tireTMNr_param);
-
-        // Transform from the vehicle frame to the tire frame
-        vehToTireTransform(tirelf_st, tirerf_st, tirelr_st, tirerr_st, veh_st, loads, m_veh_param, controls.m_steering);
-
-        // Tire dynamics
-        computeTireRHS(tirelf_st, m_tireTMNr_param, m_veh_param, controls.m_steering);
-        computeTireRHS(tirerf_st, m_tireTMNr_param, m_veh_param, controls.m_steering);
-        computeTireRHS(tirelr_st, m_tireTMNr_param, m_veh_param, 0);
-        computeTireRHS(tirerr_st, m_tireTMNr_param, m_veh_param, 0);
-
-        // Powertrain dynamics
-        computePowertrainRHS(veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st, m_veh_param, m_tireTMNr_param,
-                             controls);
-
-        // Vehicle dynamics
-        tireToVehTransform(tirelf_st, tirerf_st, tirelr_st, tirerr_st, veh_st, m_veh_param, controls.m_steering);
-        std::vector<double> fx = {tirelf_st._fx, tirerf_st._fx, tirelr_st._fx, tirerr_st._fx};
-        std::vector<double> fy = {tirelf_st._fy, tirerf_st._fy, tirelr_st._fy, tirerr_st._fy};
-        computeVehRHS(veh_st, m_veh_param, fx, fy);
-
-        // Pack the ydot and send it
-        packYDOT(veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st, m_veh_param._tcbool, ydot);
     }
 }
 
@@ -1287,217 +617,266 @@ __host__ void d18SolverHalfImplicitGPU::WriteToFile() {
 
 // ======================================================================================================================
 
-// Utility functions for finite differencing
+__device__ void rhsFun(double t, unsigned int total_num_vehicles, SimData* sim_data, SimState* sim_states) {
+    // Get the vehicle index
+    unsigned int vehicle_index = blockIdx.x * blockDim.x + threadIdx.x;
 
-void packY(const d18::VehicleState& v_states,
-           const d18::TMeasyState& tirelf_st,
-           const d18::TMeasyState& tirerf_st,
-           const d18::TMeasyState& tirelr_st,
-           const d18::TMeasyState& tirerr_st,
-           bool has_TC,
-           std::vector<double>& y) {
-    int index = 0;
+    if (vehicle_index < total_num_vehicles) {
+        // All vehicles have one or the other tire type and thus no thread divergence
+        VehicleParam& veh_param = sim_data[vehicle_index]._veh_param;
+        VehicleState& veh_state = sim_states[vehicle_index]._veh_state;
+        TMeasyParam& tireTM_param = sim_data[vehicle_index]._tireTM_param;
+        TMeasyState& tireTMlf_state = sim_states[vehicle_index]._tirelf_state;
+        TMeasyState& tireTMrf_state = sim_states[vehicle_index]._tirerf_state;
+        TMeasyState& tireTMlr_state = sim_states[vehicle_index]._tirelr_state;
+        TMeasyState& tireTMrr_state = sim_states[vehicle_index]._tirerr_state;
 
-    // Tire deflections (lf, rf, lr and rr)
+        DriverInput* driver_data = sim_data[vehicle_index]._driver_data;
+        unsigned int len = sim_data[vehicle_index]._driver_data_len;
+        // Get controls at the current timeStep
+        auto controls = GetDriverInput(t, driver_data, len);
 
-    y[index++] = tirelf_st._xe;
-    y[index++] = tirelf_st._ye;
-    y[index++] = tirerf_st._xe;
-    y[index++] = tirerf_st._ye;
-    y[index++] = tirelr_st._xe;
-    y[index++] = tirelr_st._ye;
-    y[index++] = tirerr_st._xe;
-    y[index++] = tirerr_st._ye;
+        double loads[4] = {0., 0., 0., 0.};
+        // Compute the tire loads
+        computeTireLoads(&loads[0], &veh_state, &veh_param, &tireTM_param);
+        // Transform from vehicle frame to the tire frame
+        vehToTireTransform(&tireTMlf_state, &tireTMrf_state, &tireTMlr_state, &tireTMrr_state, &veh_state, &loads[0],
+                           &veh_param, controls.m_steering);
 
-    // Wheel angular velocities (lf, rf, lr and rr)
-    y[index++] = tirelf_st._omega;
-    y[index++] = tirerf_st._omega;
-    y[index++] = tirelr_st._omega;
-    y[index++] = tirerr_st._omega;
+        // Tire velocities using TMEasy tire
+        computeTireRHS(&tireTMlf_state, &tireTM_param, &veh_param, controls.m_steering);
+        computeTireRHS(&tireTMrf_state, &tireTM_param, &veh_param, controls.m_steering);
+        computeTireRHS(&tireTMlr_state, &tireTM_param, &veh_param, 0);  // No rear steering
+        computeTireRHS(&tireTMrr_state, &tireTM_param, &veh_param, 0);  // No rear steering
 
-    // Crank angular velocity - This is a state only when a torque converter is
-    // used
-    if (has_TC) {
-        y[index++] = v_states._crankOmega;
+        // Powertrain dynamics
+        computePowertrainRHS(&veh_state, &tireTMlf_state, &tireTMrf_state, &tireTMlr_state, &tireTMrr_state, &veh_param,
+                             &tireTM_param, &controls);
+        // Vehicle dynamics
+        tireToVehTransform(&tireTMlf_state, &tireTMrf_state, &tireTMlr_state, &tireTMrr_state, &veh_state, &veh_param,
+                           controls.m_steering);
+
+        double fx[4] = {tireTMlf_state._fx, tireTMrf_state._fx, tireTMlr_state._fx, tireTMrr_state._fx};
+        double fy[4] = {tireTMlf_state._fy, tireTMrf_state._fy, tireTMlr_state._fy, tireTMrr_state._fy};
+
+        computeVehRHS(&veh_state, &veh_param, &fx[0], &fy[0]);
     }
+}
+__device__ void rhsFun(double t, unsigned int total_num_vehicles, SimDataNr* sim_data_nr, SimStateNr* sim_states_nr) {
+    // Get the vehicle index
+    unsigned int vehicle_index = blockIdx.x * blockDim.x + threadIdx.x;
 
-    // Vehicle states
-    y[index++] = v_states._x;    // X position
-    y[index++] = v_states._y;    // Y position
-    y[index++] = v_states._u;    // longitudinal velocity
-    y[index++] = v_states._v;    // lateral velocity
-    y[index++] = v_states._psi;  // yaw angle
-    y[index++] = v_states._wz;   // yaw rate
-    y[index++] = v_states._phi;  // roll angle
-    y[index++] = v_states._wx;   // roll rate
+    if (vehicle_index < total_num_vehicles) {
+        VehicleParam& veh_param = sim_data_nr[vehicle_index]._veh_param;
+        VehicleState& veh_state = sim_states_nr[vehicle_index]._veh_state;
+        TMeasyNrParam& tireTMNr_param = sim_data_nr[vehicle_index]._tireTMNr_param;
+        TMeasyNrState& tireTMNrlf_state = sim_states_nr[vehicle_index]._tirelf_state;
+        TMeasyNrState& tireTMNrrf_state = sim_states_nr[vehicle_index]._tirerf_state;
+        TMeasyNrState& tireTMNrlr_state = sim_states_nr[vehicle_index]._tirelr_state;
+        TMeasyNrState& tireTMNrrr_state = sim_states_nr[vehicle_index]._tirerr_state;
+        DriverInput* driver_data = sim_data_nr[vehicle_index]._driver_data;
+        unsigned int len = sim_data_nr[vehicle_index]._driver_data_len;
+        // Get controls at the current timeStep
+        auto controls = GetDriverInput(t, driver_data, len);
+
+        double loads[4] = {0., 0., 0., 0.};
+
+        // Compute the tire loads
+        computeTireLoads(&loads[0], &veh_state, &veh_param, &tireTMNr_param);
+        // Transform from vehicle frame to the tire frame
+        vehToTireTransform(&tireTMNrlf_state, &tireTMNrrf_state, &tireTMNrlr_state, &tireTMNrrr_state, &veh_state,
+                           &loads[0], &veh_param, controls.m_steering);
+        // Tire velocities using TMEasyNr tire
+        computeTireRHS(&tireTMNrlf_state, &tireTMNr_param, &veh_param, controls.m_steering);
+        computeTireRHS(&tireTMNrrf_state, &tireTMNr_param, &veh_param, controls.m_steering);
+        computeTireRHS(&tireTMNrlr_state, &tireTMNr_param, &veh_param, 0);  // No rear steering
+        computeTireRHS(&tireTMNrrr_state, &tireTMNr_param, &veh_param, 0);  // No rear steering
+
+        // Powertrain dynamics
+        computePowertrainRHS(&veh_state, &tireTMNrlf_state, &tireTMNrrf_state, &tireTMNrlr_state, &tireTMNrrr_state,
+                             &veh_param, &tireTMNr_param, &controls);
+
+        // Vehicle dynamics
+        tireToVehTransform(&tireTMNrlf_state, &tireTMNrrf_state, &tireTMNrlr_state, &tireTMNrrr_state, &veh_state,
+                           &veh_param, controls.m_steering);
+
+        double fx[4] = {tireTMNrlf_state._fx, tireTMNrrf_state._fx, tireTMNrlr_state._fx, tireTMNrrr_state._fx};
+        double fy[4] = {tireTMNrlf_state._fy, tireTMNrrf_state._fy, tireTMNrlr_state._fy, tireTMNrrr_state._fy};
+
+        computeVehRHS(&veh_state, &veh_param, &fx[0], &fy[0]);
+    }
 }
 
-void packY(const d18::VehicleState& v_states,
-           const d18::TMeasyNrState& tirelf_st,
-           const d18::TMeasyNrState& tirerf_st,
-           const d18::TMeasyNrState& tirelr_st,
-           const d18::TMeasyNrState& tirerr_st,
-           bool has_TC,
-           std::vector<double>& y) {
-    int index = 0;
+// ======================================================================================================================
 
-    // Wheel angular velocities (lf, rf, lr and rr)
-    y[index++] = tirelf_st._omega;
-    y[index++] = tirerf_st._omega;
-    y[index++] = tirelr_st._omega;
-    y[index++] = tirerr_st._omega;
+__global__ void Integrate(double current_time,
+                          double kernel_sim_time,
+                          double step,
+                          bool output,
+                          unsigned int total_num_vehicles,
+                          unsigned int collection_states,
+                          double dtout,
+                          double* device_response,
+                          SimData* sim_data,
+                          SimState* sim_states) {
+    double t = current_time;           // Set the current time
+    double kernel_time = 0;            // Time since kernel was launched
+    unsigned int timeStep_stored = 0;  // Number of time steps already stored in the device response
+    double end_time = (t + kernel_sim_time) - step / 10.;
+    unsigned int vehicle_id = blockIdx.x * blockDim.x + threadIdx.x;  // Get the vehicle id
+    while (t < end_time) {
+        // Call the RHS to get accelerations for all the vehicles
+        rhsFun(t, total_num_vehicles, sim_data, sim_states);
 
-    // Crank angular velocity - This is a state only when a torque converter is
-    // used
-    if (has_TC) {
-        y[index++] = v_states._crankOmega;
+        // Integrate according to half implicit method for second order states
+        // Integrate according to explicit method for first order states
+
+        // Extract the states of the vehicle and the tires
+        VehicleState& v_states = sim_states[vehicle_id]._veh_state;
+        VehicleParam& veh_param = sim_data[vehicle_id]._veh_param;
+        TMeasyState& tirelf_st = sim_states[vehicle_id]._tirelf_state;
+        TMeasyState& tirerf_st = sim_states[vehicle_id]._tirerf_state;
+        TMeasyState& tirelr_st = sim_states[vehicle_id]._tirelr_state;
+        TMeasyState& tirerr_st = sim_states[vehicle_id]._tirerr_state;
+
+        // First the tire states
+        // LF
+        tirelf_st._xe += tirelf_st._xedot * step;
+        tirelf_st._ye += tirelf_st._yedot * step;
+        tirelf_st._omega += tirelf_st._dOmega * step;
+        // RF
+        tirerf_st._xe += tirerf_st._xedot * step;
+        tirerf_st._ye += tirerf_st._yedot * step;
+        tirerf_st._omega += tirerf_st._dOmega * step;
+        // LR
+        tirelr_st._xe += tirelr_st._xedot * step;
+        tirelr_st._ye += tirelr_st._yedot * step;
+        tirelr_st._omega += tirelr_st._dOmega * step;
+        // RR
+        tirerr_st._xe += tirerr_st._xedot * step;
+        tirerr_st._ye += tirerr_st._yedot * step;
+        tirerr_st._omega += tirerr_st._dOmega * step;
+
+        // Now the vehicle states
+        if (veh_param._tcbool) {
+            v_states._crankOmega += v_states._dOmega_crank * step;
+        }
+
+        // Integrate velocity level first
+        v_states._u += v_states._udot * step;
+        v_states._v += v_states._vdot * step;
+        v_states._wx += v_states._wxdot * step;
+        v_states._wz += v_states._wzdot * step;
+
+        // Integrate position level next
+        v_states._x += (v_states._u * cos(v_states._psi) - v_states._v * sin(v_states._psi)) * step;
+        v_states._y += (v_states._u * sin(v_states._psi) + v_states._v * cos(v_states._psi)) * step;
+        v_states._psi += v_states._wz * step;
+        v_states._phi += v_states._wx * step;
+
+        // Update time
+        t += step;
+        kernel_time += step;
+
+        // Write to response if required -> regardless of no_outs or store_all we write all the vehicles to the
+        // response
+        if (output) {
+            if (abs(kernel_time - timeStep_stored * dtout) < 1e-7) {
+                unsigned int time_offset = timeStep_stored * total_num_vehicles * collection_states;
+
+                device_response[time_offset + (total_num_vehicles * 0) + vehicle_id] = t;
+                device_response[time_offset + (total_num_vehicles * 1) + vehicle_id] = v_states._x;
+                device_response[time_offset + (total_num_vehicles * 2) + vehicle_id] = v_states._y;
+                device_response[time_offset + (total_num_vehicles * 3) + vehicle_id] = v_states._u;
+                device_response[time_offset + (total_num_vehicles * 4) + vehicle_id] = v_states._v;
+                device_response[time_offset + (total_num_vehicles * 5) + vehicle_id] = v_states._phi;
+                device_response[time_offset + (total_num_vehicles * 6) + vehicle_id] = v_states._psi;
+                device_response[time_offset + (total_num_vehicles * 7) + vehicle_id] = v_states._wx;
+                device_response[time_offset + (total_num_vehicles * 8) + vehicle_id] = v_states._wz;
+                device_response[time_offset + (total_num_vehicles * 9) + vehicle_id] = tirelf_st._omega;
+                device_response[time_offset + (total_num_vehicles * 10) + vehicle_id] = tirerf_st._omega;
+                device_response[time_offset + (total_num_vehicles * 11) + vehicle_id] = tirelr_st._omega;
+                device_response[time_offset + (total_num_vehicles * 12) + vehicle_id] = tirerr_st._omega;
+            }
+        }
     }
-
-    // Vehicle states
-    y[index++] = v_states._x;    // X position
-    y[index++] = v_states._y;    // Y position
-    y[index++] = v_states._u;    // longitudinal velocity
-    y[index++] = v_states._v;    // lateral velocity
-    y[index++] = v_states._psi;  // yaw angle
-    y[index++] = v_states._wz;   // yaw rate
-    y[index++] = v_states._phi;  // roll angle
-    y[index++] = v_states._wx;   // roll rate
 }
+__global__ void Integrate(double current_time,
+                          double kernel_sim_time,
+                          double step,
+                          bool output,
+                          unsigned int total_num_vehicles,
+                          unsigned int collection_states,
+                          double dtout,
+                          double* device_response,
+                          SimDataNr* sim_data_nr,
+                          SimStateNr* sim_states_nr) {
+    double t = current_time;           // Set the current time
+    double kernel_time = 0;            // Time since kernel was launched
+    unsigned int timeStep_stored = 0;  // Number of time steps already stored in the device response
 
-void packYDOT(const d18::VehicleState& v_states,
-              const d18::TMeasyState& tirelf_st,
-              const d18::TMeasyState& tirerf_st,
-              const d18::TMeasyState& tirelr_st,
-              const d18::TMeasyState& tirerr_st,
-              bool has_TC,
-              std::vector<double>& ydot) {
-    int index = 0;
+    unsigned int vehicle_id = blockIdx.x * blockDim.x + threadIdx.x;  // Get the vehicle id
+    while (t < ((t + kernel_sim_time) - step / 10.)) {
+        // Call the RHS to get accelerations for all the vehicles
+        rhsFun(t, total_num_vehicles, sim_data_nr, sim_states_nr);
+        // Extract the states of the vehicle and the tires
+        VehicleState& v_states = sim_states_nr[vehicle_id]._veh_state;
+        VehicleParam& veh_param = sim_data_nr[vehicle_id]._veh_param;
+        TMeasyNrState& tirelf_st = sim_states_nr[vehicle_id]._tirelf_state;
+        TMeasyNrState& tirerf_st = sim_states_nr[vehicle_id]._tirerf_state;
+        TMeasyNrState& tirelr_st = sim_states_nr[vehicle_id]._tirelr_state;
+        TMeasyNrState& tirerr_st = sim_states_nr[vehicle_id]._tirerr_state;
 
-    ydot[index++] = tirelf_st._xedot;
-    ydot[index++] = tirelf_st._yedot;
-    ydot[index++] = tirerf_st._xedot;
-    ydot[index++] = tirerf_st._yedot;
-    ydot[index++] = tirelr_st._xedot;
-    ydot[index++] = tirelr_st._yedot;
-    ydot[index++] = tirerr_st._xedot;
-    ydot[index++] = tirerr_st._yedot;
+        // First the tire states
+        // LF
+        tirelf_st._omega += tirelf_st._dOmega * step;
+        // RF
+        tirerf_st._omega += tirerf_st._dOmega * step;
+        // LR
+        tirelr_st._omega += tirelr_st._dOmega * step;
+        // RR
+        tirerr_st._omega += tirerr_st._dOmega * step;
 
-    ydot[index++] = tirelf_st._dOmega;
-    ydot[index++] = tirerf_st._dOmega;
-    ydot[index++] = tirelr_st._dOmega;
-    ydot[index++] = tirerr_st._dOmega;
+        // Now the vehicle states
+        if (veh_param._tcbool) {
+            v_states._crankOmega += v_states._dOmega_crank * step;
+        }
 
-    if (has_TC) {
-        ydot[index++] = v_states._dOmega_crank;
+        // Integrate velocity level first
+        v_states._u += v_states._udot * step;
+        v_states._v += v_states._vdot * step;
+        v_states._wx += v_states._wxdot * step;
+        v_states._wz += v_states._wzdot * step;
+        // Integrate position level next
+        v_states._x += (v_states._u * cos(v_states._psi) - v_states._v * sin(v_states._psi)) * step;
+        v_states._y += (v_states._u * sin(v_states._psi) + v_states._v * cos(v_states._psi)) * step;
+        v_states._psi += v_states._wz * step;
+        v_states._phi += v_states._wx * step;
+
+        // Update time
+        t += step;
+        kernel_time += step;
+
+        // Write to response if required -> regardless of no_outs or store_all we write all the vehicles to the
+        // response
+        if (output) {
+            if (abs(kernel_time - timeStep_stored * dtout) < 1e-7) {
+                unsigned int time_offset = timeStep_stored * total_num_vehicles * collection_states;
+
+                device_response[time_offset + (total_num_vehicles * 0) + vehicle_id] = t;
+                device_response[time_offset + (total_num_vehicles * 1) + vehicle_id] = v_states._x;
+                device_response[time_offset + (total_num_vehicles * 2) + vehicle_id] = v_states._y;
+                device_response[time_offset + (total_num_vehicles * 3) + vehicle_id] = v_states._u;
+                device_response[time_offset + (total_num_vehicles * 4) + vehicle_id] = v_states._v;
+                device_response[time_offset + (total_num_vehicles * 5) + vehicle_id] = v_states._phi;
+                device_response[time_offset + (total_num_vehicles * 6) + vehicle_id] = v_states._psi;
+                device_response[time_offset + (total_num_vehicles * 7) + vehicle_id] = v_states._wx;
+                device_response[time_offset + (total_num_vehicles * 8) + vehicle_id] = v_states._wz;
+                device_response[time_offset + (total_num_vehicles * 9) + vehicle_id] = tirelf_st._omega;
+                device_response[time_offset + (total_num_vehicles * 10) + vehicle_id] = tirerf_st._omega;
+                device_response[time_offset + (total_num_vehicles * 11) + vehicle_id] = tirelr_st._omega;
+                device_response[time_offset + (total_num_vehicles * 12) + vehicle_id] = tirerr_st._omega;
+            }
+        }
     }
-
-    ydot[index++] = v_states._dx;
-    ydot[index++] = v_states._dy;
-    ydot[index++] = v_states._udot;
-    ydot[index++] = v_states._vdot;
-    ydot[index++] = v_states._wz;
-    ydot[index++] = v_states._wzdot;
-    ydot[index++] = v_states._wx;
-    ydot[index++] = v_states._wxdot;
-}
-
-void packYDOT(const d18::VehicleState& v_states,
-              const d18::TMeasyNrState& tirelf_st,
-              const d18::TMeasyNrState& tirerf_st,
-              const d18::TMeasyNrState& tirelr_st,
-              const d18::TMeasyNrState& tirerr_st,
-              bool has_TC,
-              std::vector<double>& ydot) {
-    int index = 0;
-
-    ydot[index++] = tirelf_st._dOmega;
-    ydot[index++] = tirerf_st._dOmega;
-    ydot[index++] = tirelr_st._dOmega;
-    ydot[index++] = tirerr_st._dOmega;
-
-    if (has_TC) {
-        ydot[index++] = v_states._dOmega_crank;
-    }
-
-    ydot[index++] = v_states._dx;
-    ydot[index++] = v_states._dy;
-    ydot[index++] = v_states._udot;
-    ydot[index++] = v_states._vdot;
-    ydot[index++] = v_states._wz;
-    ydot[index++] = v_states._wzdot;
-    ydot[index++] = v_states._wx;
-    ydot[index++] = v_states._wxdot;
-}
-
-void unpackY(const std::vector<double>& y,
-             bool has_TC,
-             d18::VehicleState& v_states,
-             d18::TMeasyState& tirelf_st,
-             d18::TMeasyState& tirerf_st,
-             d18::TMeasyState& tirelr_st,
-             d18::TMeasyState& tirerr_st) {
-    int index = 0;
-    // Tire deflections
-    tirelf_st._xe = y[index++];
-    tirelf_st._ye = y[index++];
-    tirerf_st._xe = y[index++];
-    tirerf_st._ye = y[index++];
-    tirelr_st._xe = y[index++];
-    tirelr_st._ye = y[index++];
-    tirerr_st._xe = y[index++];
-    tirerr_st._ye = y[index++];
-
-    // Wheel angular velocities
-    tirelf_st._omega = y[index++];
-    tirerf_st._omega = y[index++];
-    tirelr_st._omega = y[index++];
-    tirerr_st._omega = y[index++];
-
-    // Crank angular velocity - This is a state only when a torque converter is
-    // used
-    if (has_TC) {
-        v_states._crankOmega = y[index++];
-    }
-
-    // Vehicle states
-    v_states._x = y[index++];    // X position
-    v_states._y = y[index++];    // Y position
-    v_states._u = y[index++];    // longitudinal velocity
-    v_states._v = y[index++];    // lateral velocity
-    v_states._psi = y[index++];  // yaw angle
-    v_states._wz = y[index++];   // yaw rate
-    v_states._phi = y[index++];  // roll angle
-    v_states._wx = y[index++];   // roll rate
-}
-
-void unpackY(const std::vector<double>& y,
-             bool has_TC,
-             d18::VehicleState& v_states,
-             d18::TMeasyNrState& tirelf_st,
-             d18::TMeasyNrState& tirerf_st,
-             d18::TMeasyNrState& tirelr_st,
-             d18::TMeasyNrState& tirerr_st) {
-    int index = 0;
-
-    // Wheel angular velocities
-    tirelf_st._omega = y[index++];
-    tirerf_st._omega = y[index++];
-    tirelr_st._omega = y[index++];
-    tirerr_st._omega = y[index++];
-
-    // Crank angular velocity - This is a state only when a torque converter is
-    // used
-    if (has_TC) {
-        v_states._crankOmega = y[index++];
-    }
-
-    // Vehicle states
-    v_states._x = y[index++];    // X position
-    v_states._y = y[index++];    // Y position
-    v_states._u = y[index++];    // longitudinal velocity
-    v_states._v = y[index++];    // lateral velocity
-    v_states._psi = y[index++];  // yaw angle
-    v_states._wz = y[index++];   // yaw rate
-    v_states._phi = y[index++];  // roll angle
-    v_states._wx = y[index++];   // roll rate
 }

--- a/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cu
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cu
@@ -548,9 +548,7 @@ __host__ double d18SolverHalfImplicitGPU::SolveStep(double t,
     m_time_since_last_dump += m_kernel_sim_time;
     return m_current_time;
 }
-
-// ======================================================================================================================
-
+//======================================================================================================================
 __host__ void d18SolverHalfImplicitGPU::Write(double t, unsigned int time_steps_to_write) {
     unsigned int loop_limit = 0;
     if (m_store_all) {
@@ -879,7 +877,7 @@ __device__ void rhsFun(double t,
         computeVehRHS(&veh_state, &veh_param, &fx[0], &fy[0]);
     }
 }
-// ======================================================================================================================
+//======================================================================================================================
 
 __global__ void Integrate(double current_time,
                           double kernel_sim_time,

--- a/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cu
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cu
@@ -493,6 +493,64 @@ __host__ void d18SolverHalfImplicitGPU::Solve() {
     }
 }
 
+//======================================================================================================================
+__host__ double d18SolverHalfImplicitGPU::SolveStep(double t,
+                                                    double steering,
+                                                    double throttle,
+                                                    double braking) {  // Calculate the number of blocks required
+    // if m_output is true, then raise assertion
+    if (m_output) {
+        // Handle the error: log, return an error code, etc.
+        std::cerr << "Cannot get csv file output if SolveStep is called, please access sim_states through GetSimSate"
+                  << std::endl;
+        exit(EXIT_FAILURE);
+    }
+    m_num_blocks = (m_total_num_vehicles + m_threads_per_block - 1) / m_threads_per_block;
+    // If m_output is false and its the first time step then we still need to initialize device array -> We don't need
+    // the host array as its purpose is just to store the final output
+    if (t == 0.) {
+        // Number of time steps to be collected on the device
+        m_device_collection_timeSteps = ceil(m_kernel_sim_time / m_dtout);
+
+        // Number of states to store -> For now we only allow storage of the major states which are common to both tire
+        // models [time,x,y,u,v,phi,psi,wx,wz,lf_omega,rf_omega,lr_omega,rr_omega]
+        m_collection_states = 13;
+
+        // Thus device array size becomes
+        m_device_size = sizeof(double) * m_total_num_vehicles * m_collection_states * (m_device_collection_timeSteps);
+
+        CHECK_CUDA_ERROR(cudaMalloc((void**)&m_device_response, m_device_size));
+    }
+    m_current_time = t;
+
+    // Launch the kernel
+    double kernel_end_time = m_current_time + m_kernel_sim_time;
+
+    if (m_tire_type == TireType::TMeasy) {
+        Integrate<<<m_num_blocks, m_threads_per_block>>>(m_current_time, steering, throttle, braking, m_kernel_sim_time,
+                                                         m_step, m_output, m_total_num_vehicles, m_collection_states,
+                                                         m_dtout, m_device_response, m_sim_data, m_sim_states);
+        cudaError_t err = cudaGetLastError();
+        if (err != cudaSuccess) {
+            fprintf(stderr, "Kernel launch failed: %s\n", cudaGetErrorString(err));
+        }
+    } else {
+        Integrate<<<m_num_blocks, m_threads_per_block>>>(m_current_time, steering, throttle, braking, m_kernel_sim_time,
+                                                         m_step, m_output, m_total_num_vehicles, m_collection_states,
+                                                         m_dtout, m_device_response, m_sim_data_nr, m_sim_states_nr);
+        cudaError_t err = cudaGetLastError();
+        if (err != cudaSuccess) {
+            fprintf(stderr, "Kernel launch failed: %s\n", cudaGetErrorString(err));
+        }
+    }
+
+    m_current_time = kernel_end_time;
+    m_time_since_last_dump += m_kernel_sim_time;
+    return m_current_time;
+}
+
+// ======================================================================================================================
+
 __host__ void d18SolverHalfImplicitGPU::Write(double t, unsigned int time_steps_to_write) {
     unsigned int loop_limit = 0;
     if (m_store_all) {
@@ -611,9 +669,6 @@ __host__ void d18SolverHalfImplicitGPU::WriteToFile() {
 __host__ SimState d18SolverHalfImplicitGPU::GetSimState(unsigned int vehicle_index) {
     assert((vehicle_index < m_total_num_vehicles) && "Vehicle index out of bounds");
 
-    // Synchronize to ensure all GPU operations are completed
-    cudaDeviceSynchronize();
-
     // Allocate space for a single SimState on the host
     SimState host_state;
 
@@ -674,6 +729,60 @@ __device__ void rhsFun(double t, unsigned int total_num_vehicles, SimData* sim_d
         computeVehRHS(&veh_state, &veh_param, &fx[0], &fy[0]);
     }
 }
+// ======================================================================================================================
+__device__ void rhsFun(double t,
+                       unsigned int total_num_vehicles,
+                       d18::SimData* sim_data,
+                       d18::SimState* sim_states,
+                       double steering,
+                       double throttle,
+                       double braking) {
+    // Get the vehicle index
+    unsigned int vehicle_index = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (vehicle_index < total_num_vehicles) {
+        // All vehicles have one or the other tire type and thus no thread divergence
+        VehicleParam& veh_param = sim_data[vehicle_index]._veh_param;
+        VehicleState& veh_state = sim_states[vehicle_index]._veh_state;
+        TMeasyParam& tireTM_param = sim_data[vehicle_index]._tireTM_param;
+        TMeasyState& tireTMlf_state = sim_states[vehicle_index]._tirelf_state;
+        TMeasyState& tireTMrf_state = sim_states[vehicle_index]._tirerf_state;
+        TMeasyState& tireTMlr_state = sim_states[vehicle_index]._tirelr_state;
+        TMeasyState& tireTMrr_state = sim_states[vehicle_index]._tirerr_state;
+
+        // Get controls at the current timeStep
+        DriverInput controls;
+        controls.m_steering = steering;
+        controls.m_throttle = throttle;
+        controls.m_braking = braking;
+
+        double loads[4] = {0., 0., 0., 0.};
+        // Compute the tire loads
+        computeTireLoads(&loads[0], &veh_state, &veh_param, &tireTM_param);
+        // Transform from vehicle frame to the tire frame
+        vehToTireTransform(&tireTMlf_state, &tireTMrf_state, &tireTMlr_state, &tireTMrr_state, &veh_state, &loads[0],
+                           &veh_param, controls.m_steering);
+
+        // Tire velocities using TMEasy tire
+        computeTireRHS(&tireTMlf_state, &tireTM_param, &veh_param, controls.m_steering);
+        computeTireRHS(&tireTMrf_state, &tireTM_param, &veh_param, controls.m_steering);
+        computeTireRHS(&tireTMlr_state, &tireTM_param, &veh_param, 0);  // No rear steering
+        computeTireRHS(&tireTMrr_state, &tireTM_param, &veh_param, 0);  // No rear steering
+
+        // Powertrain dynamics
+        computePowertrainRHS(&veh_state, &tireTMlf_state, &tireTMrf_state, &tireTMlr_state, &tireTMrr_state, &veh_param,
+                             &tireTM_param, &controls);
+        // Vehicle dynamics
+        tireToVehTransform(&tireTMlf_state, &tireTMrf_state, &tireTMlr_state, &tireTMrr_state, &veh_state, &veh_param,
+                           controls.m_steering);
+
+        double fx[4] = {tireTMlf_state._fx, tireTMrf_state._fx, tireTMlr_state._fx, tireTMrr_state._fx};
+        double fy[4] = {tireTMlf_state._fy, tireTMrf_state._fy, tireTMlr_state._fy, tireTMrr_state._fy};
+
+        computeVehRHS(&veh_state, &veh_param, &fx[0], &fy[0]);
+    }
+}
+// ======================================================================================================================
 __device__ void rhsFun(double t, unsigned int total_num_vehicles, SimDataNr* sim_data_nr, SimStateNr* sim_states_nr) {
     // Get the vehicle index
     unsigned int vehicle_index = blockIdx.x * blockDim.x + threadIdx.x;
@@ -718,7 +827,58 @@ __device__ void rhsFun(double t, unsigned int total_num_vehicles, SimDataNr* sim
         computeVehRHS(&veh_state, &veh_param, &fx[0], &fy[0]);
     }
 }
+// ======================================================================================================================
+__device__ void rhsFun(double t,
+                       unsigned int total_num_vehicles,
+                       d18::SimDataNr* sim_data_nr,
+                       d18::SimStateNr* sim_states_nr,
+                       double steering,
+                       double throttle,
+                       double braking) {
+    // Get the vehicle index
+    unsigned int vehicle_index = blockIdx.x * blockDim.x + threadIdx.x;
 
+    if (vehicle_index < total_num_vehicles) {
+        VehicleParam& veh_param = sim_data_nr[vehicle_index]._veh_param;
+        VehicleState& veh_state = sim_states_nr[vehicle_index]._veh_state;
+        TMeasyNrParam& tireTMNr_param = sim_data_nr[vehicle_index]._tireTMNr_param;
+        TMeasyNrState& tireTMNrlf_state = sim_states_nr[vehicle_index]._tirelf_state;
+        TMeasyNrState& tireTMNrrf_state = sim_states_nr[vehicle_index]._tirerf_state;
+        TMeasyNrState& tireTMNrlr_state = sim_states_nr[vehicle_index]._tirelr_state;
+        TMeasyNrState& tireTMNrrr_state = sim_states_nr[vehicle_index]._tirerr_state;
+
+        DriverInput controls;
+        controls.m_steering = steering;
+        controls.m_throttle = throttle;
+        controls.m_braking = braking;
+
+        double loads[4] = {0., 0., 0., 0.};
+
+        // Compute the tire loads
+        computeTireLoads(&loads[0], &veh_state, &veh_param, &tireTMNr_param);
+        // Transform from vehicle frame to the tire frame
+        vehToTireTransform(&tireTMNrlf_state, &tireTMNrrf_state, &tireTMNrlr_state, &tireTMNrrr_state, &veh_state,
+                           &loads[0], &veh_param, controls.m_steering);
+        // Tire velocities using TMEasyNr tire
+        computeTireRHS(&tireTMNrlf_state, &tireTMNr_param, &veh_param, controls.m_steering);
+        computeTireRHS(&tireTMNrrf_state, &tireTMNr_param, &veh_param, controls.m_steering);
+        computeTireRHS(&tireTMNrlr_state, &tireTMNr_param, &veh_param, 0);  // No rear steering
+        computeTireRHS(&tireTMNrrr_state, &tireTMNr_param, &veh_param, 0);  // No rear steering
+
+        // Powertrain dynamics
+        computePowertrainRHS(&veh_state, &tireTMNrlf_state, &tireTMNrrf_state, &tireTMNrlr_state, &tireTMNrrr_state,
+                             &veh_param, &tireTMNr_param, &controls);
+
+        // Vehicle dynamics
+        tireToVehTransform(&tireTMNrlf_state, &tireTMNrrf_state, &tireTMNrlr_state, &tireTMNrrr_state, &veh_state,
+                           &veh_param, controls.m_steering);
+
+        double fx[4] = {tireTMNrlf_state._fx, tireTMNrrf_state._fx, tireTMNrlr_state._fx, tireTMNrrr_state._fx};
+        double fy[4] = {tireTMNrlf_state._fy, tireTMNrrf_state._fy, tireTMNrlr_state._fy, tireTMNrrr_state._fy};
+
+        computeVehRHS(&veh_state, &veh_param, &fx[0], &fy[0]);
+    }
+}
 // ======================================================================================================================
 
 __global__ void Integrate(double current_time,
@@ -817,6 +977,107 @@ __global__ void Integrate(double current_time,
         }
     }
 }
+// ======================================================================================================================
+__global__ void Integrate(double current_time,
+                          double steering,
+                          double throttle,
+                          double braking,
+                          double kernel_sim_time,
+                          double step,
+                          bool output,
+                          unsigned int total_num_vehicles,
+                          unsigned int collection_states,
+                          double dtout,
+                          double* device_response,
+                          d18::SimData* sim_data,
+                          d18::SimState* sim_states) {
+    double t = current_time;           // Set the current time
+    double kernel_time = 0;            // Time since kernel was launched
+    unsigned int timeStep_stored = 0;  // Number of time steps already stored in the device response
+    double end_time = (t + kernel_sim_time) - step / 10.;
+    unsigned int vehicle_id = blockIdx.x * blockDim.x + threadIdx.x;  // Get the vehicle id
+    if (vehicle_id < total_num_vehicles) {
+        while (t < end_time) {
+            // Call the RHS to get accelerations for all the vehicles
+            rhsFun(t, total_num_vehicles, sim_data, sim_states, steering, throttle, braking);
+
+            // Integrate according to half implicit method for second order states
+            // Integrate according to explicit method for first order states
+
+            // Extract the states of the vehicle and the tires
+            VehicleState& v_states = sim_states[vehicle_id]._veh_state;
+            VehicleParam& veh_param = sim_data[vehicle_id]._veh_param;
+            TMeasyState& tirelf_st = sim_states[vehicle_id]._tirelf_state;
+            TMeasyState& tirerf_st = sim_states[vehicle_id]._tirerf_state;
+            TMeasyState& tirelr_st = sim_states[vehicle_id]._tirelr_state;
+            TMeasyState& tirerr_st = sim_states[vehicle_id]._tirerr_state;
+
+            // First the tire states
+            // LF
+            tirelf_st._xe += tirelf_st._xedot * step;
+            tirelf_st._ye += tirelf_st._yedot * step;
+            tirelf_st._omega += tirelf_st._dOmega * step;
+            // RF
+            tirerf_st._xe += tirerf_st._xedot * step;
+            tirerf_st._ye += tirerf_st._yedot * step;
+            tirerf_st._omega += tirerf_st._dOmega * step;
+            // LR
+            tirelr_st._xe += tirelr_st._xedot * step;
+            tirelr_st._ye += tirelr_st._yedot * step;
+            tirelr_st._omega += tirelr_st._dOmega * step;
+            // RR
+            tirerr_st._xe += tirerr_st._xedot * step;
+            tirerr_st._ye += tirerr_st._yedot * step;
+            tirerr_st._omega += tirerr_st._dOmega * step;
+
+            // Now the vehicle states
+            if (veh_param._tcbool) {
+                v_states._crankOmega += v_states._dOmega_crank * step;
+            }
+
+            // Integrate velocity level first
+            v_states._u += v_states._udot * step;
+            v_states._v += v_states._vdot * step;
+            v_states._wx += v_states._wxdot * step;
+            v_states._wz += v_states._wzdot * step;
+
+            // Integrate position level next
+            v_states._x += (v_states._u * cos(v_states._psi) - v_states._v * sin(v_states._psi)) * step;
+            v_states._y += (v_states._u * sin(v_states._psi) + v_states._v * cos(v_states._psi)) * step;
+            v_states._psi += v_states._wz * step;
+            v_states._phi += v_states._wx * step;
+
+            // Update time
+            t += step;
+            kernel_time += step;
+
+            // Write to response if required -> regardless of no_outs or store_all we write all the vehicles to the
+            // response
+            if (output) {
+                // The +1 here is because state at time 0 is not stored in device response
+                if (abs(kernel_time - (timeStep_stored + 1) * dtout) < 1e-7) {
+                    unsigned int time_offset = timeStep_stored * total_num_vehicles * collection_states;
+
+                    device_response[time_offset + (total_num_vehicles * 0) + vehicle_id] = t;
+                    device_response[time_offset + (total_num_vehicles * 1) + vehicle_id] = v_states._x;
+                    device_response[time_offset + (total_num_vehicles * 2) + vehicle_id] = v_states._y;
+                    device_response[time_offset + (total_num_vehicles * 3) + vehicle_id] = v_states._u;
+                    device_response[time_offset + (total_num_vehicles * 4) + vehicle_id] = v_states._v;
+                    device_response[time_offset + (total_num_vehicles * 5) + vehicle_id] = v_states._phi;
+                    device_response[time_offset + (total_num_vehicles * 6) + vehicle_id] = v_states._psi;
+                    device_response[time_offset + (total_num_vehicles * 7) + vehicle_id] = v_states._wx;
+                    device_response[time_offset + (total_num_vehicles * 8) + vehicle_id] = v_states._wz;
+                    device_response[time_offset + (total_num_vehicles * 9) + vehicle_id] = tirelf_st._omega;
+                    device_response[time_offset + (total_num_vehicles * 10) + vehicle_id] = tirerf_st._omega;
+                    device_response[time_offset + (total_num_vehicles * 11) + vehicle_id] = tirelr_st._omega;
+                    device_response[time_offset + (total_num_vehicles * 12) + vehicle_id] = tirerr_st._omega;
+                    timeStep_stored++;
+                }
+            }
+        }
+    }
+}
+// ======================================================================================================================
 __global__ void Integrate(double current_time,
                           double kernel_sim_time,
                           double step,
@@ -837,6 +1098,94 @@ __global__ void Integrate(double current_time,
         while (t < end_time) {
             // Call the RHS to get accelerations for all the vehicles
             rhsFun(t, total_num_vehicles, sim_data_nr, sim_states_nr);
+            // Extract the states of the vehicle and the tires
+            VehicleState& v_states = sim_states_nr[vehicle_id]._veh_state;
+            VehicleParam& veh_param = sim_data_nr[vehicle_id]._veh_param;
+            TMeasyNrState& tirelf_st = sim_states_nr[vehicle_id]._tirelf_state;
+            TMeasyNrState& tirerf_st = sim_states_nr[vehicle_id]._tirerf_state;
+            TMeasyNrState& tirelr_st = sim_states_nr[vehicle_id]._tirelr_state;
+            TMeasyNrState& tirerr_st = sim_states_nr[vehicle_id]._tirerr_state;
+
+            // First the tire states
+            // LF
+            tirelf_st._omega += tirelf_st._dOmega * step;
+            // RF
+            tirerf_st._omega += tirerf_st._dOmega * step;
+            // LR
+            tirelr_st._omega += tirelr_st._dOmega * step;
+            // RR
+            tirerr_st._omega += tirerr_st._dOmega * step;
+
+            // Now the vehicle states
+            if (veh_param._tcbool) {
+                v_states._crankOmega += v_states._dOmega_crank * step;
+            }
+
+            // Integrate velocity level first
+            v_states._u += v_states._udot * step;
+            v_states._v += v_states._vdot * step;
+            v_states._wx += v_states._wxdot * step;
+            v_states._wz += v_states._wzdot * step;
+            // Integrate position level next
+            v_states._x += (v_states._u * cos(v_states._psi) - v_states._v * sin(v_states._psi)) * step;
+            v_states._y += (v_states._u * sin(v_states._psi) + v_states._v * cos(v_states._psi)) * step;
+            v_states._psi += v_states._wz * step;
+            v_states._phi += v_states._wx * step;
+
+            // Update time
+            t += step;
+            kernel_time += step;
+
+            // Write to response if required -> regardless of no_outs or store_all we write all the vehicles to the
+            // response
+            if (output) {
+                // The +1 here is because state at time 0 is not stored in device response
+                if (abs(kernel_time - (timeStep_stored + 1) * dtout) < 1e-7) {
+                    unsigned int time_offset = timeStep_stored * total_num_vehicles * collection_states;
+
+                    device_response[time_offset + (total_num_vehicles * 0) + vehicle_id] = t;
+                    device_response[time_offset + (total_num_vehicles * 1) + vehicle_id] = v_states._x;
+                    device_response[time_offset + (total_num_vehicles * 2) + vehicle_id] = v_states._y;
+                    device_response[time_offset + (total_num_vehicles * 3) + vehicle_id] = v_states._u;
+                    device_response[time_offset + (total_num_vehicles * 4) + vehicle_id] = v_states._v;
+                    device_response[time_offset + (total_num_vehicles * 5) + vehicle_id] = v_states._phi;
+                    device_response[time_offset + (total_num_vehicles * 6) + vehicle_id] = v_states._psi;
+                    device_response[time_offset + (total_num_vehicles * 7) + vehicle_id] = v_states._wx;
+                    device_response[time_offset + (total_num_vehicles * 8) + vehicle_id] = v_states._wz;
+                    device_response[time_offset + (total_num_vehicles * 9) + vehicle_id] = tirelf_st._omega;
+                    device_response[time_offset + (total_num_vehicles * 10) + vehicle_id] = tirerf_st._omega;
+                    device_response[time_offset + (total_num_vehicles * 11) + vehicle_id] = tirelr_st._omega;
+                    device_response[time_offset + (total_num_vehicles * 12) + vehicle_id] = tirerr_st._omega;
+                    timeStep_stored++;
+                }
+            }
+        }
+    }
+}
+// ======================================================================================================================
+__global__ void Integrate(double current_time,
+                          double steering,
+                          double throttle,
+                          double braking,
+                          double kernel_sim_time,
+                          double step,
+                          bool output,
+                          unsigned int total_num_vehicles,
+                          unsigned int collection_states,
+                          double dtout,
+                          double* device_response,
+                          d18::SimDataNr* sim_data_nr,
+                          d18::SimStateNr* sim_states_nr) {
+    double t = current_time;           // Set the current time
+    double kernel_time = 0;            // Time since kernel was launched
+    unsigned int timeStep_stored = 0;  // Number of time steps already stored in the device response
+
+    unsigned int vehicle_id = blockIdx.x * blockDim.x + threadIdx.x;  // Get the vehicle id
+    double end_time = (t + kernel_sim_time) - step / 10.;
+    if (vehicle_id < total_num_vehicles) {
+        while (t < end_time) {
+            // Call the RHS to get accelerations for all the vehicles
+            rhsFun(t, total_num_vehicles, sim_data_nr, sim_states_nr, steering, throttle, braking);
             // Extract the states of the vehicle and the tires
             VehicleState& v_states = sim_states_nr[vehicle_id]._veh_state;
             VehicleParam& veh_param = sim_data_nr[vehicle_id]._veh_param;

--- a/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cu
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cu
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cassert>
+#include <random>
 #include <cmath>
 #include <iostream>
 #include <stdint.h>
@@ -11,7 +12,14 @@
 using namespace d18;
 // ======================================================================================================================
 d18SolverHalfImplicitGPU::d18SolverHalfImplicitGPU(unsigned int total_num_vehicles)
-    : m_step(0.001), m_output(false), m_csv(" "), m_vehicle_count_tracker_params(0), m_vehicle_count_tracker_states(0) {
+    : m_step(0.001),
+      m_output(false),
+      m_vehicle_count_tracker_params(0),
+      m_vehicle_count_tracker_states(0),
+      m_kernel_sim_time(2.),
+      m_host_dump_time(10.),
+      m_threads_per_block(32),
+      m_tend(0.) {
     m_total_num_vehicles = total_num_vehicles;
 
     // Allocate memory for the simData and simStates
@@ -19,6 +27,10 @@ d18SolverHalfImplicitGPU::d18SolverHalfImplicitGPU(unsigned int total_num_vehicl
     CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_data_nr, sizeof(d18::SimDataNr) * m_total_num_vehicles));
     CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_states, sizeof(d18::SimState) * m_total_num_vehicles));
     CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_states_nr, sizeof(d18::SimStateNr) * m_total_num_vehicles));
+
+    // Set device and host arrays to nullptrs in case SetOutput is not called by the user
+    m_device_response = nullptr;
+    m_host_response = nullptr;
 }
 d18SolverHalfImplicitGPU::~d18SolverHalfImplicitGPU() {
     // Only need to delete the memory of the simData and simStates of the respective tire as the rest of the memory is
@@ -26,14 +38,12 @@ d18SolverHalfImplicitGPU::~d18SolverHalfImplicitGPU() {
     if (m_tire_type == TireType::TMeasy) {
         cudaFree(m_sim_data);
         cudaFree(m_sim_states);
-        cudaFree(device_response);
-        delete[] host_response;
     } else {
         cudaFree(m_sim_data_nr);
         cudaFree(m_sim_states_nr);
-        cudaFree(device_response_nr);
-        delete[] host_response_nr;
     }
+    cudaFree(m_device_response);
+    delete[] m_host_response;
 }
 // ======================================================================================================================
 // Construct the solver using path to vehicle parameters, tire parameters, number of vehicles and driver
@@ -49,11 +59,9 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
     // Because of this, we free the memory of the TMeasyNR tire
     cudaFree(m_sim_data_nr);
     cudaFree(m_sim_states_nr);
-    cudaFree(device_response_nr);
     // Set these to nullptr so that we don't try to free them again in the destructor
     m_sim_data_nr = nullptr;
     m_sim_states_nr = nullptr;
-    device_response_nr = nullptr;
 
     // Since cudaMallocManaged does not call the constructor for non-POD types, we create cpu structs and fill them up
     // and then copy them over to the simData structs
@@ -80,8 +88,6 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
         // Fill up simulation data from the cpu structs
         m_sim_data[i]._veh_param = veh_param;
         m_sim_data[i]._tireTM_param = tire_param;
-        // Set the final integration time for each of the vehicles
-        m_sim_data[i]._t_end = driver_data.back().m_time;
     }
     cudaMemPrefetchAsync(&m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
                          0);  // move the simData onto the GPU
@@ -102,11 +108,9 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
         // Because of this, we free the memory of the TMeasyNR tire
         cudaFree(m_sim_data_nr);
         cudaFree(m_sim_states_nr);
-        cudaFree(device_response_nr);
         // Set these to nullptr so that we don't try to free them again in the destructor
         m_sim_data_nr = nullptr;
         m_sim_states_nr = nullptr;
-        device_response_nr = nullptr;
 
         // Since cudaMallocManaged does not call the constructor for non-POD types, we create cpu structs and fill them
         // up and then copy them over to the simData structs
@@ -133,8 +137,6 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
             // Fill up simulation data from the cpu structs
             m_sim_data[i]._veh_param = veh_param;
             m_sim_data[i]._tireTM_param = tire_param;
-            // Set the final integration time for each of the vehicles
-            m_sim_data[i]._t_end = driver_data.back().m_time;
         }
         cudaMemPrefetchAsync(&m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
                              0);  // move the simData onto the GPU
@@ -142,11 +144,9 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
         // Because of this, we free the memory of the TMeasyNR tire
         cudaFree(m_sim_data);
         cudaFree(m_sim_states);
-        cudaFree(device_response);
         // Set these to nullptr so that we don't try to free them again in the destructor
         m_sim_data = nullptr;
         m_sim_states = nullptr;
-        device_response = nullptr;
 
         // Since cudaMallocManaged does not call the constructor for non-POD types, we create cpu structs and fill them
         // up and then copy them over to the simData structs
@@ -193,11 +193,9 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
     // Because of this, we free the memory of the TMeasyNR tire
     cudaFree(m_sim_data_nr);
     cudaFree(m_sim_states_nr);
-    cudaFree(device_response_nr);
     // Set these to nullptr so that we don't try to free them again in the destructor
     m_sim_data_nr = nullptr;
     m_sim_states_nr = nullptr;
-    device_response_nr = nullptr;
 
     // Since cudaMallocManaged does not call the constructor for non-POD types, we create cpu structs and fill them up
     // and then copy them over to the simData structs
@@ -234,11 +232,9 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
         // Because of this, we free the memory of the TMeasyNR tire
         cudaFree(m_sim_data_nr);
         cudaFree(m_sim_states_nr);
-        cudaFree(device_response_nr);
         // Set these to nullptr so that we don't try to free them again in the destructor
         m_sim_data_nr = nullptr;
         m_sim_states_nr = nullptr;
-        device_response_nr = nullptr;
 
         // Since cudaMallocManaged does not call the constructor for non-POD types, we create cpu structs and fill them
         // up and then copy them over to the simData structs
@@ -263,11 +259,9 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
         // Because of this, we free the memory of the TMeasyNR tire
         cudaFree(m_sim_data);
         cudaFree(m_sim_states);
-        cudaFree(device_response);
         // Set these to nullptr so that we don't try to free them again in the destructor
         m_sim_data = nullptr;
         m_sim_states = nullptr;
-        device_response = nullptr;
 
         // Since cudaMallocManaged does not call the constructor for non-POD types, we create cpu structs and fill them
         // up and then copy them over to the simData structs
@@ -367,107 +361,252 @@ __host__ void d18SolverHalfImplicitGPU::Initialize(d18::VehicleState& vehicle_st
 }
 
 // ======================================================================================================================
-
-/// @brief Sets the path for the output file
-/// @param output_file string with full path with extension
-void d18SolverHalfImplicitGPU::SetOutput(const std::string& output_file, double output_freq) {
+__host__ void d18SolverHalfImplicitGPU::SetOutput(const std::string& output_file,
+                                                  double output_freq,
+                                                  bool store_all = false,
+                                                  unsigned int no_outs = 50) {
     m_output = true;
+    m_store_all = store_all;
+    if (!m_store_all) {
+        m_num_outs = no_outs;
+        // If store_all is false, randomly assign which vehicles need to be dumped into csv
+        float some_seed = 68;
+        std::mt19937 generator(some_seed);
+        const int minval_input = 0., maxval_input = m_total_num_vehicles - 1;
+        std::uniform_int_distribution<int> dist_input(minval_input, maxval_input);
+
+        m_which_outs.resize(no_outs);
+        // fill in our numbers
+        for (std::size_t i = 0; i < no_outs; i++) {
+            m_which_outs[i] = dist_input(generator);
+        }
+    }
     m_output_file = output_file;
-    m_timeStepsStored = 0;
     m_dtout = 1.0 / output_freq;
+
+    // Here we also initialize the device and host arrays that store the response across vehicles and states -> If
+    // output is not required, then nothing is stored, however the user has access to the states at the last time step
+    // through the simState and simData structs
+
+    // Number of time steps to be collected on the device
+    m_device_collection_timeSteps = ceil(m_kernel_sim_time / m_dtout);
+
+    // Number of states to store -> For now we only allow storage of the major states which are common to both tire
+    // models [time,x,y,u,v,phi,psi,wx,wz,lf_omega,rf_omega,lr_omega,rr_omega]
+    m_collection_states = 13;
+
+    // Thus device array size becomes
+    m_device_size = sizeof(double) * m_total_num_vehicles * m_collection_states * (m_device_collection_timeSteps);
+
+    CHECK_CUDA_ERROR(cudaMalloc((void**)&m_device_response, m_device_size));
+
+    // Now the host response
+    m_host_collection_timeSteps = ceil(m_host_dump_time / m_dtout);
+
+    // Thus the host size becomes -> Usually much larger than the device size
+    m_host_response = new double[m_total_num_vehicles * m_collection_states * (m_host_collection_timeSteps)];
 }
 
 // ======================================================================================================================
 
 /// @brief Solve the system of equations by calling the integrate function
-void d18SolverHalfImplicitGPU::Solve() {
+__host__ void d18SolverHalfImplicitGPU::Solve() {
     assert(!m_driver_data.empty() && "No controls provided, please use construct to pass path to driver inputs");
+    assert(m_tend != 0. && "Final time not set, please use SetEndTime function");
+    // Calculate the number of blocks required
+    m_num_blocks = (m_total_num_vehicles + m_threads_per_block - 1) / m_threads_per_block;
 
-    // For now just integrate to final time
-    Integrate();
+    double current_time = 0.;
+    unsigned int kernel_launches_since_last_dump = 0;  // Track the number of kernel launches since the last dump of the
+                                                       // host response
+    double time_since_last_dump = 0.;                  // Track the time since the last dump of the host response
+
+    while (current_time < m_tend) {
+        // Calculate when this kernel is supposed to end
+
+        double kernel_end_time = current_time + m_kernel_sim_time;
+
+        // Launch the kernel
+        Integrate<<<m_num_blocks, m_threads_per_block>>>(current_time);
+
+        // Get the new time the simulation has reached
+        current_time = kernel_end_time;
+        time_since_last_dump += m_kernel_sim_time;
+
+        // If we have to save output, copy over the device into the response
+        if (m_output) {
+            // Amount of respoonse already filled
+            unsigned int filled_response = m_total_num_vehicles * m_collection_states * m_device_collection_timeSteps *
+                                           kernel_launches_since_last_dump;
+
+            // Copy the device to the right part of the host response
+            CHECK_CUDA_ERROR(cudaMemcpy(m_host_response + filled_response, m_device_response, m_device_size,
+                                        cudaMemcpyDeviceToHost));
+
+            kernel_launches_since_last_dump++;
+
+            // Check if host is full and dump that into a csv writer
+            if (time_since_last_dump > m_host_dump_time) {
+                Write(current_time);
+                time_since_last_dump = 0.;
+                kernel_launches_since_last_dump = 0;
+            }
+        }
+    }
+
+    // End of simulation, write to the csv file
+    if (m_output) {
+        WriteToFile();
+    }
 }
 
 // ======================================================================================================================
 
 /// @brief Integrate the system of equations using the half implicit method - Calls the RHS function at each time step
-void d18SolverHalfImplicitGPU::Integrate() {
-    double t = 0;
-    // Create output writer
-    if (m_output) {
-        Write(t);
-        m_timeStepsStored++;
-    }
+__device__ void d18SolverHalfImplicitGPU::Integrate(double current_time) {
+    double t = current_time;           // Set the current time
+    double kernel_time = 0;            // Time since kernel was launched
+    unsigned int timeStep_stored = 0;  // Number of time steps already stored in the device response
 
-    // Integrate to final time by repeatedly calling the RHS function
-    while (t < (m_tend - m_step / 10.)) {
-        // Call RHS to get all accelerations
+    unsigned int vehicle_id = blockIdx.x * blockDim.x + threadIdx.x;  // Get the vehicle id
+    while (t < ((t + m_kernel_sim_time) - m_step / 10.)) {
+        // Call the RHS to get accelerations for all the vehicles
         rhsFun(t);
 
         // Integrate according to half implicit method for second order states
         // Integrate according to explicit method for first order states
 
-        if (m_tire_type == TireType::TMeasy) {  // Only TM easy has xe and ye states
+        if (m_tire_type == TireType::TMeasy) {
+            // Extract the states of the vehicle and the tires
+            VehicleState& v_states = m_sim_states[vehicle_id]._veh_state;
+            VehicleParam& veh_param = m_sim_data[vehicle_id]._veh_param;
+            TMeasyState& tirelf_st = m_sim_states[vehicle_id]._tirelf_state;
+            TMeasyState& tirerf_st = m_sim_states[vehicle_id]._tirerf_state;
+            TMeasyState& tirelr_st = m_sim_states[vehicle_id]._tirelr_state;
+            TMeasyState& tirerr_st = m_sim_states[vehicle_id]._tirerr_state;
+
             // First the tire states
             // LF
-            m_tireTMlf_state._xe += m_tireTMlf_state._xedot * m_step;
-            m_tireTMlf_state._ye += m_tireTMlf_state._yedot * m_step;
-            m_tireTMlf_state._omega += m_tireTMlf_state._dOmega * m_step;
+            tirelf_st._xe += tirelf_st._xedot * m_step;
+            tirelf_st._ye += tirelf_st._yedot * m_step;
+            tirelf_st._omega += tirelf_st._dOmega * m_step;
             // RF
-            m_tireTMrf_state._xe += m_tireTMrf_state._xedot * m_step;
-            m_tireTMrf_state._ye += m_tireTMrf_state._yedot * m_step;
-            m_tireTMrf_state._omega += m_tireTMrf_state._dOmega * m_step;
+            tirerf_st._xe += tirerf_st._xedot * m_step;
+            tirerf_st._ye += tirerf_st._yedot * m_step;
+            tirerf_st._omega += tirerf_st._dOmega * m_step;
             // LR
-            m_tireTMlr_state._xe += m_tireTMlr_state._xedot * m_step;
-            m_tireTMlr_state._ye += m_tireTMlr_state._yedot * m_step;
-            m_tireTMlr_state._omega += m_tireTMlr_state._dOmega * m_step;
+            tirelr_st._xe += tirelr_st._xedot * m_step;
+            tirelr_st._ye += tirelr_st._yedot * m_step;
+            tirelr_st._omega += tirelr_st._dOmega * m_step;
             // RR
-            m_tireTMrr_state._xe += m_tireTMrr_state._xedot * m_step;
-            m_tireTMrr_state._ye += m_tireTMrr_state._yedot * m_step;
-            m_tireTMrr_state._omega += m_tireTMrr_state._dOmega * m_step;
-        } else {  // Other tires have only omega states
+            tirerr_st._xe += tirerr_st._xedot * m_step;
+            tirerr_st._ye += tirerr_st._yedot * m_step;
+            tirerr_st._omega += tirerr_st._dOmega * m_step;
+
+            // Now the vehicle states
+            if (veh_param._tcbool) {
+                v_states._crankOmega += v_states._dOmega_crank * m_step;
+            }
+
+            // Integrate velocity level first
+            v_states._u += v_states._udot * m_step;
+            v_states._v += v_states._vdot * m_step;
+            v_states._wx += v_states._wxdot * m_step;
+            v_states._wz += v_states._wzdot * m_step;
+
+            // Integrate position level next
+            v_states._x += (v_states._u * cos(v_states._psi) - v_states._v * sin(v_states._psi)) * m_step;
+            v_states._y += (v_states._u * sin(v_states._psi) + v_states._v * cos(v_states._psi)) * m_step;
+            v_states._psi += v_states._wz * m_step;
+            v_states._phi += v_states._wx * m_step;
+
+            // Update time
+            t += m_step;
+            kernel_time += m_step;
+
+            // Write to response if required -> regardless of no_outs or store_all we write all the vehicles to the
+            // response
+            if (m_output) {
+                if (abs(kernel_time - timeStep_stored * m_dtout) < 1e-7) {
+                    unsigned int time_offset = timeStep_stored * m_total_num_vehicles * m_collection_states;
+
+                    m_device_response[time_offset + (m_total_num_vehicles * 0) + vehicle_id] = t;
+                    m_device_response[time_offset + (m_total_num_vehicles * 1) + vehicle_id] = v_states._x;
+                    m_device_response[time_offset + (m_total_num_vehicles * 2) + vehicle_id] = v_states._y;
+                    m_device_response[time_offset + (m_total_num_vehicles * 3) + vehicle_id] = v_states._u;
+                    m_device_response[time_offset + (m_total_num_vehicles * 4) + vehicle_id] = v_states._v;
+                    m_device_response[time_offset + (m_total_num_vehicles * 5) + vehicle_id] = v_states._phi;
+                    m_device_response[time_offset + (m_total_num_vehicles * 6) + vehicle_id] = v_states._psi;
+                    m_device_response[time_offset + (m_total_num_vehicles * 7) + vehicle_id] = v_states._wx;
+                    m_device_response[time_offset + (m_total_num_vehicles * 8) + vehicle_id] = v_states._wz;
+                    m_device_response[time_offset + (m_total_num_vehicles * 9) + vehicle_id] = tirelf_st._omega;
+                    m_device_response[time_offset + (m_total_num_vehicles * 10) + vehicle_id] = tirerf_st._omega;
+                    m_device_response[time_offset + (m_total_num_vehicles * 11) + vehicle_id] = tirelr_st._omega;
+                    m_device_response[time_offset + (m_total_num_vehicles * 12) + vehicle_id] = tirerr_st._omega;
+                }
+            }
+
+        } else {
+            // Extract the states of the vehicle and the tires
+            VehicleState& v_states = m_sim_states_nr[vehicle_id]._veh_state;
+            VehicleParam& veh_param = m_sim_data_nr[vehicle_id]._veh_param;
+            TMeasyNrState& tirelf_st = m_sim_states_nr[vehicle_id]._tirelf_state;
+            TMeasyNrState& tirerf_st = m_sim_states_nr[vehicle_id]._tirerf_state;
+            TMeasyNrState& tirelr_st = m_sim_states_nr[vehicle_id]._tirelr_state;
+            TMeasyNrState& tirerr_st = m_sim_states_nr[vehicle_id]._tirerr_state;
+
             // First the tire states
             // LF
-            m_tireTMNrlf_state._omega += m_tireTMNrlf_state._dOmega * m_step;
+            tirelf_st._omega += tirelf_st._dOmega * m_step;
             // RF
-            m_tireTMNrrf_state._omega += m_tireTMNrrf_state._dOmega * m_step;
+            tirerf_st._omega += tirerf_st._dOmega * m_step;
             // LR
-            m_tireTMNrlr_state._omega += m_tireTMNrlr_state._dOmega * m_step;
+            tirelr_st._omega += tirelr_st._dOmega * m_step;
             // RR
-            m_tireTMNrrr_state._omega += m_tireTMNrrr_state._dOmega * m_step;
-        }
+            tirerr_st._omega += tirerr_st._dOmega * m_step;
 
-        // Now the vehicle states
-        if (m_veh_param._tcbool) {
-            m_veh_state._crankOmega += m_veh_state._dOmega_crank * m_step;
-        }
+            // Now the vehicle states
+            if (veh_param._tcbool) {
+                v_states._crankOmega += v_states._dOmega_crank * m_step;
+            }
 
-        // Integrate velocity level first
-        m_veh_state._u += m_veh_state._udot * m_step;
-        m_veh_state._v += m_veh_state._vdot * m_step;
-        m_veh_state._wx += m_veh_state._wxdot * m_step;
-        m_veh_state._wz += m_veh_state._wzdot * m_step;
+            // Integrate velocity level first
+            v_states._u += v_states._udot * m_step;
+            v_states._v += v_states._vdot * m_step;
+            v_states._wx += v_states._wxdot * m_step;
+            v_states._wz += v_states._wzdot * m_step;
+            // Integrate position level next
+            v_states._x += (v_states._u * cos(v_states._psi) - v_states._v * sin(v_states._psi)) * m_step;
+            v_states._y += (v_states._u * sin(v_states._psi) + v_states._v * cos(v_states._psi)) * m_step;
+            v_states._psi += v_states._wz * m_step;
+            v_states._phi += v_states._wx * m_step;
 
-        // Integrate position level next
-        m_veh_state._x +=
-            (m_veh_state._u * std::cos(m_veh_state._psi) - m_veh_state._v * std::sin(m_veh_state._psi)) * m_step;
-        m_veh_state._y +=
-            (m_veh_state._u * std::sin(m_veh_state._psi) + m_veh_state._v * std::cos(m_veh_state._psi)) * m_step;
-        m_veh_state._psi += m_veh_state._wz * m_step;
-        m_veh_state._phi += m_veh_state._wx * m_step;
+            // Update time
+            t += m_step;
+            kernel_time += m_step;
 
-        // Update time
-        t += m_step;
+            // Write to response if required -> regardless of no_outs or store_all we write all the vehicles to the
+            // response
+            if (m_output) {
+                if (abs(kernel_time - timeStep_stored * m_dtout) < 1e-7) {
+                    unsigned int time_offset = timeStep_stored * m_total_num_vehicles * m_collection_states;
 
-        // Write the output
-        if (m_output) {
-            if (std::abs(t - m_timeStepsStored * m_dtout) < 1e-7) {
-                Write(t);
-                m_timeStepsStored++;
+                    m_device_response[time_offset + (m_total_num_vehicles * 0) + vehicle_id] = t;
+                    m_device_response[time_offset + (m_total_num_vehicles * 1) + vehicle_id] = v_states._x;
+                    m_device_response[time_offset + (m_total_num_vehicles * 2) + vehicle_id] = v_states._y;
+                    m_device_response[time_offset + (m_total_num_vehicles * 3) + vehicle_id] = v_states._u;
+                    m_device_response[time_offset + (m_total_num_vehicles * 4) + vehicle_id] = v_states._v;
+                    m_device_response[time_offset + (m_total_num_vehicles * 5) + vehicle_id] = v_states._phi;
+                    m_device_response[time_offset + (m_total_num_vehicles * 6) + vehicle_id] = v_states._psi;
+                    m_device_response[time_offset + (m_total_num_vehicles * 7) + vehicle_id] = v_states._wx;
+                    m_device_response[time_offset + (m_total_num_vehicles * 8) + vehicle_id] = v_states._wz;
+                    m_device_response[time_offset + (m_total_num_vehicles * 9) + vehicle_id] = tirelf_st._omega;
+                    m_device_response[time_offset + (m_total_num_vehicles * 10) + vehicle_id] = tirerf_st._omega;
+                    m_device_response[time_offset + (m_total_num_vehicles * 11) + vehicle_id] = tirelr_st._omega;
+                    m_device_response[time_offset + (m_total_num_vehicles * 12) + vehicle_id] = tirerr_st._omega;
+                }
             }
         }
-    }
-    if (m_output) {
-        WriteToFile();
     }
 }
 // ======================================================================================================================
@@ -767,96 +906,90 @@ double d18SolverHalfImplicitGPU::IntegrateStepWithJacobian(double t,
 
 /// @brief Computes the RHS of all the ODEs (tire velocities, chassis accelerations)
 /// @param t Current time
-void d18SolverHalfImplicitGPU::rhsFun(double t) {
-    // Get controls at the current timeStep
-    auto controls = GetDriverInput(t, m_driver_data);
+__device__ void d18SolverHalfImplicitGPU::rhsFun(double t) {
+    // Get the vehicle index
+    unsigned int vehicle_index = blockIdx.x * blockDim.x + threadIdx.x;
 
-    // Calculate tire vertical loads
-    std::vector<double> loads(4, 0);
-    if (m_tire_type == TireType::TMeasy) {
-        computeTireLoads(loads, m_veh_state, m_veh_param, m_tireTM_param);
+    if (vehicle_index < m_total_num_vehicles) {
+        // All vehicles have one or the other tire type and thus no thread divergence
+        if (m_tire_type == TireType::TMeasy) {
+            VehicleParam& veh_param = m_sim_data[vehicle_index]._veh_param;
+            VehicleState& veh_state = m_sim_states[vehicle_index]._veh_state;
+            TMeasyParam& tireTM_param = m_sim_data[vehicle_index]._tireTM_param;
+            TMeasyState& tireTMlf_state = m_sim_states[vehicle_index]._tirelf_state;
+            TMeasyState& tireTMrf_state = m_sim_states[vehicle_index]._tirerf_state;
+            TMeasyState& tireTMlr_state = m_sim_states[vehicle_index]._tirelr_state;
+            TMeasyState& tireTMrr_state = m_sim_states[vehicle_index]._tirerr_state;
 
-        // Transform from vehicle frame to the tire frame
-        vehToTireTransform(m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state, m_veh_state, loads,
-                           m_veh_param, controls.m_steering);
+            DriverInput* driver_data = m_sim_data[vehicle_index]._driver_data;
+            unsigned int len = m_sim_data[vehicle_index]._driver_data_len;
+            // Get controls at the current timeStep
+            auto controls = GetDriverInput(t, driver_data, len);
 
-        // Tire velocities using TMEasy tire
-        computeTireRHS(m_tireTMlf_state, m_tireTM_param, m_veh_param, controls.m_steering);
-        computeTireRHS(m_tireTMrf_state, m_tireTM_param, m_veh_param, controls.m_steering);
-        computeTireRHS(m_tireTMlr_state, m_tireTM_param, m_veh_param, 0);  // No rear steering
-        computeTireRHS(m_tireTMrr_state, m_tireTM_param, m_veh_param, 0);  // No rear steering
+            double loads[4] = {0., 0., 0., 0.};
+            // Compute the tire loads
+            computeTireLoads(&loads[0], &veh_state, &veh_param, &tireTM_param);
+            // Transform from vehicle frame to the tire frame
+            vehToTireTransform(&tireTMlf_state, &tireTMrf_state, &tireTMlr_state, &tireTMrr_state, &veh_state,
+                               &loads[0], &veh_param, controls.m_steering);
 
-        // Powertrain dynamics
-        computePowertrainRHS(m_veh_state, m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state,
-                             m_veh_param, m_tireTM_param, controls);
-//////// DEBUG
-#ifdef DEBUG
-        M_DEBUG_LF_TIRE_FX = m_tireTMlf_state._fx;
-        M_DEBUG_RF_TIRE_FX = m_tireTMrf_state._fx;
-        M_DEBUG_LR_TIRE_FX = m_tireTMlr_state._fx;
-        M_DEBUG_RR_TIRE_FX = m_tireTMrr_state._fx;
+            // Tire velocities using TMEasy tire
+            computeTireRHS(&tireTMlf_state, &tireTM_param, &veh_param, controls.m_steering);
+            computeTireRHS(&tireTMrf_state, &tireTM_param, &veh_param, controls.m_steering);
+            computeTireRHS(&tireTMlr_state, &tireTM_param, &veh_param, 0);  // No rear steering
+            computeTireRHS(&tireTMrr_state, &tireTM_param, &veh_param, 0);  // No rear steering
 
-        M_DEBUG_LF_TIRE_FY = m_tireTMlf_state._fy;
-        M_DEBUG_RF_TIRE_FY = m_tireTMrf_state._fy;
-        M_DEBUG_LR_TIRE_FY = m_tireTMlr_state._fy;
-        M_DEBUG_RR_TIRE_FY = m_tireTMrr_state._fy;
+            // Powertrain dynamics
+            computePowertrainRHS(&veh_state, &tireTMlf_state, &tireTMrf_state, &tireTMlr_state, &tireTMrr_state,
+                                 &veh_param, &tireTM_param, &controls);
+            // Vehicle dynamics
+            tireToVehTransform(&tireTMlf_state, &tireTMrf_state, &tireTMlr_state, &tireTMrr_state, &veh_state,
+                               &veh_param, controls.m_steering);
 
-        M_DEBUG_LF_TIRE_FZ = m_tireTMlf_state._fz;
-        M_DEBUG_RF_TIRE_FZ = m_tireTMrf_state._fz;
-        M_DEBUG_LR_TIRE_FZ = m_tireTMlr_state._fz;
-        M_DEBUG_RR_TIRE_FZ = m_tireTMrr_state._fz;
-#endif
+            double fx[4] = {tireTMlf_state._fx, tireTMrf_state._fx, tireTMlr_state._fx, tireTMrr_state._fx};
+            double fy[4] = {tireTMlf_state._fy, tireTMrf_state._fy, tireTMlr_state._fy, tireTMrr_state._fy};
 
-        // Vehicle dynamics
-        tireToVehTransform(m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state, m_veh_state,
-                           m_veh_param, controls.m_steering);
-        std::vector<double> fx = {m_tireTMlf_state._fx, m_tireTMrf_state._fx, m_tireTMlr_state._fx,
-                                  m_tireTMrr_state._fx};
-        std::vector<double> fy = {m_tireTMlf_state._fy, m_tireTMrf_state._fy, m_tireTMlr_state._fy,
-                                  m_tireTMrr_state._fy};
-        computeVehRHS(m_veh_state, m_veh_param, fx, fy);
-    } else {  // For the other tire
-        computeTireLoads(loads, m_veh_state, m_veh_param, m_tireTMNr_param);
+            computeVehRHS(&veh_state, &veh_param, &fx[0], &fy[0]);
 
-        // Transform from vehicle frame to the tire frame
-        vehToTireTransform(m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state, m_tireTMNrrr_state, m_veh_state,
-                           loads, m_veh_param, controls.m_steering);
+        } else {
+            VehicleParam& veh_param = m_sim_data_nr[vehicle_index]._veh_param;
+            VehicleState& veh_state = m_sim_states_nr[vehicle_index]._veh_state;
+            TMeasyNrParam& tireTMNr_param = m_sim_data_nr[vehicle_index]._tireTMNr_param;
+            TMeasyNrState& tireTMNrlf_state = m_sim_states_nr[vehicle_index]._tirelf_state;
+            TMeasyNrState& tireTMNrrf_state = m_sim_states_nr[vehicle_index]._tirerf_state;
+            TMeasyNrState& tireTMNrlr_state = m_sim_states_nr[vehicle_index]._tirelr_state;
+            TMeasyNrState& tireTMNrrr_state = m_sim_states_nr[vehicle_index]._tirerr_state;
+            DriverInput* driver_data = m_sim_data_nr[vehicle_index]._driver_data;
+            unsigned int len = m_sim_data_nr[vehicle_index]._driver_data_len;
+            // Get controls at the current timeStep
+            auto controls = GetDriverInput(t, driver_data, len);
 
-        // Tire velocities using TMEasy tire
-        computeTireRHS(m_tireTMNrlf_state, m_tireTMNr_param, m_veh_param, controls.m_steering);
-        computeTireRHS(m_tireTMNrrf_state, m_tireTMNr_param, m_veh_param, controls.m_steering);
-        computeTireRHS(m_tireTMNrlr_state, m_tireTMNr_param, m_veh_param, 0);  // No rear steering
-        computeTireRHS(m_tireTMNrrr_state, m_tireTMNr_param, m_veh_param, 0);  // No rear steering
+            double loads[4] = {0., 0., 0., 0.};
 
-        // Powertrain dynamics
-        computePowertrainRHS(m_veh_state, m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state,
-                             m_tireTMNrrr_state, m_veh_param, m_tireTMNr_param, controls);
-//////// DEBUG
-#ifdef DEBUG
-        M_DEBUG_LF_TIRE_FX = m_tireTMNrlf_state._fx;
-        M_DEBUG_RF_TIRE_FX = m_tireTMNrrf_state._fx;
-        M_DEBUG_LR_TIRE_FX = m_tireTMNrlr_state._fx;
-        M_DEBUG_RR_TIRE_FX = m_tireTMNrrr_state._fx;
+            // Compute the tire loads
+            computeTireLoads(&loads[0], &veh_state, &veh_param, &tireTMNr_param);
+            // Transform from vehicle frame to the tire frame
+            vehToTireTransform(&tireTMNrlf_state, &tireTMNrrf_state, &tireTMNrlr_state, &tireTMNrrr_state, &veh_state,
+                               &loads[0], &veh_param, controls.m_steering);
+            // Tire velocities using TMEasyNr tire
+            computeTireRHS(&tireTMNrlf_state, &tireTMNr_param, &veh_param, controls.m_steering);
+            computeTireRHS(&tireTMNrrf_state, &tireTMNr_param, &veh_param, controls.m_steering);
+            computeTireRHS(&tireTMNrlr_state, &tireTMNr_param, &veh_param, 0);  // No rear steering
+            computeTireRHS(&tireTMNrrr_state, &tireTMNr_param, &veh_param, 0);  // No rear steering
 
-        M_DEBUG_LF_TIRE_FY = m_tireTMNrlf_state._fy;
-        M_DEBUG_RF_TIRE_FY = m_tireTMNrrf_state._fy;
-        M_DEBUG_LR_TIRE_FY = m_tireTMNrlr_state._fy;
-        M_DEBUG_RR_TIRE_FY = m_tireTMNrrr_state._fy;
+            // Powertrain dynamics
+            computePowertrainRHS(&veh_state, &tireTMNrlf_state, &tireTMNrrf_state, &tireTMNrlr_state, &tireTMNrrr_state,
+                                 &veh_param, &tireTMNr_param, &controls);
 
-        M_DEBUG_LF_TIRE_FZ = m_tireTMNrlf_state._fz;
-        M_DEBUG_RF_TIRE_FZ = m_tireTMNrrf_state._fz;
-        M_DEBUG_LR_TIRE_FZ = m_tireTMNrlr_state._fz;
-        M_DEBUG_RR_TIRE_FZ = m_tireTMNrrr_state._fz;
-#endif
+            // Vehicle dynamics
+            tireToVehTransform(&tireTMNrlf_state, &tireTMNrrf_state, &tireTMNrlr_state, &tireTMNrrr_state, &veh_state,
+                               &veh_param, controls.m_steering);
 
-        // Vehicle dynamics
-        tireToVehTransform(m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state, m_tireTMNrrr_state, m_veh_state,
-                           m_veh_param, controls.m_steering);
-        std::vector<double> fx = {m_tireTMNrlf_state._fx, m_tireTMNrrf_state._fx, m_tireTMNrlr_state._fx,
-                                  m_tireTMNrrr_state._fx};
-        std::vector<double> fy = {m_tireTMNrlf_state._fy, m_tireTMNrrf_state._fy, m_tireTMNrlr_state._fy,
-                                  m_tireTMNrrr_state._fy};
-        computeVehRHS(m_veh_state, m_veh_param, fx, fy);
+            double fx[4] = {tireTMNrlf_state._fx, tireTMNrrf_state._fx, tireTMNrlr_state._fx, tireTMNrrr_state._fx};
+            double fy[4] = {tireTMNrlf_state._fy, tireTMNrrf_state._fy, tireTMNrlr_state._fy, tireTMNrrr_state._fy};
+
+            computeVehRHS(&veh_state, &veh_param, &fx[0], &fy[0]);
+        }
     }
 }
 
@@ -991,131 +1124,165 @@ void d18SolverHalfImplicitGPU::PerturbRhsFun(std::vector<double>& y, DriverInput
     }
 }
 
-void d18SolverHalfImplicitGPU::Write(double t) {
-    // If we are in initial time step, write the header
-    if (t < m_step) {
-        m_csv << "time";
-        m_csv << "x";
-        m_csv << "y";
-        m_csv << "vx";
-        m_csv << "vy";
-        m_csv << "ax";
-        m_csv << "ay";
-        m_csv << "roll";
-        m_csv << "yaw";
-        m_csv << "roll_rate";
-        m_csv << "yaw_rate";
-        m_csv << "wlf";
-        m_csv << "wrf";
-        m_csv << "wlr";
-        m_csv << "wrr";
-        m_csv << "sp_tor";
-        m_csv << "current_gear";
-        m_csv << "engine_omega";
-#ifdef DEBUG
-        m_csv << "lf_tireForce_x";
-        m_csv << "rf_tireForce_x";
-        m_csv << "lr_tireForce_x";
-        m_csv << "rr_tireForce_x";
-        m_csv << "lf_tireForce_y";
-        m_csv << "rf_tireForce_y";
-        m_csv << "lr_tireForce_y";
-        m_csv << "rr_tireForce_y";
-        m_csv << "lf_tireForce_z";
-        m_csv << "rf_tireForce_z";
-        m_csv << "lr_tireForce_z";
-        m_csv << "rr_tireForce_z";
-#endif
-        m_csv << std::endl;
-
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-#ifdef DEBUG
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-        m_csv << 0;
-#endif
-        m_csv << std::endl;
-        return;
-    }
-
-    m_csv << t;
-    m_csv << m_veh_state._x;
-    m_csv << m_veh_state._y;
-    m_csv << m_veh_state._u;
-    m_csv << m_veh_state._v;
-    m_csv << m_veh_state._udot;
-    m_csv << m_veh_state._vdot;
-    m_csv << m_veh_state._phi;
-    m_csv << m_veh_state._psi;
-    m_csv << m_veh_state._wx;
-    m_csv << m_veh_state._wz;
-    if (m_tire_type == TireType::TMeasy) {
-        m_csv << m_tireTMlf_state._omega;
-        m_csv << m_tireTMrf_state._omega;
-        m_csv << m_tireTMlr_state._omega;
-        m_csv << m_tireTMrr_state._omega;
+__host__ void d18SolverHalfImplicitGPU::Write(double t) {
+    unsigned int loop_limit = 0;
+    if (m_store_all) {
+        loop_limit = m_total_num_vehicles;
     } else {
-        m_csv << m_tireTMNrlf_state._omega;
-        m_csv << m_tireTMNrrf_state._omega;
-        m_csv << m_tireTMNrlr_state._omega;
-        m_csv << m_tireTMNrrr_state._omega;
+        loop_limit = m_num_outs;
     }
-    m_csv << m_veh_state._tor / 4.;
-    m_csv << m_veh_state._current_gr + 1;
-    m_csv << m_veh_state._crankOmega;
-#ifdef DEBUG
-    m_csv << M_DEBUG_LF_TIRE_FX;
-    m_csv << M_DEBUG_RF_TIRE_FX;
-    m_csv << M_DEBUG_LR_TIRE_FX;
-    m_csv << M_DEBUG_RR_TIRE_FX;
-    m_csv << M_DEBUG_LF_TIRE_FY;
-    m_csv << M_DEBUG_RF_TIRE_FY;
-    m_csv << M_DEBUG_LR_TIRE_FY;
-    m_csv << M_DEBUG_RR_TIRE_FY;
-    m_csv << M_DEBUG_LF_TIRE_FZ;
-    m_csv << M_DEBUG_RF_TIRE_FZ;
-    m_csv << M_DEBUG_LR_TIRE_FZ;
-    m_csv << M_DEBUG_RR_TIRE_FZ;
-#endif
-    m_csv << std::endl;
+
+    for (unsigned int sim_no = 0; sim_no < loop_limit; sim_no++) {
+        unsigned int index_by = 0;
+        // If we are no storing all, we will have to index by random numbers
+        if (m_store_all) {
+            index_by = sim_no;
+        } else {
+            index_by = m_which_outs[sim_no];
+        }
+        if (m_tire_type == TireType::TMeasy) {
+            CSV_writer& csv = m_sim_data[index_by]._csv;
+            // If we are in initial time step, write the header
+            if (t < m_step) {
+                csv << "time";
+                csv << "x";
+                csv << "y";
+                csv << "vx";
+                csv << "vy";
+                csv << "roll";
+                csv << "yaw";
+                csv << "roll_rate";
+                csv << "yaw_rate";
+                csv << "wlf";
+                csv << "wrf";
+                csv << "wlr";
+                csv << "wrr";
+                csv << std::endl;
+
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << std::endl;
+                return;
+            }
+            unsigned int steps_written = 0;
+            while (steps_written < m_host_collection_timeSteps) {
+                unsigned int time_offset = steps_written * m_total_num_vehicles * m_collection_states;
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 0) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 1) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 2) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 3) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 4) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 5) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 6) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 7) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 8) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 9) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 10) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 11) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 12) + index_by];
+                csv << std::endl;
+                steps_written++;
+            }
+        } else {
+            CSV_writer& csv = m_sim_data_nr[index_by]._csv;
+            // If we are in initial time step, write the header
+            if (t < m_step) {
+                csv << "time";
+                csv << "x";
+                csv << "y";
+                csv << "vx";
+                csv << "vy";
+                csv << "roll";
+                csv << "yaw";
+                csv << "roll_rate";
+                csv << "yaw_rate";
+                csv << "wlf";
+                csv << "wrf";
+                csv << "wlr";
+                csv << "wrr";
+                csv << std::endl;
+
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << 0;
+                csv << std::endl;
+                return;
+            }
+            unsigned int steps_written = 0;
+            while (steps_written < m_host_collection_timeSteps) {
+                unsigned int time_offset = steps_written * m_total_num_vehicles * m_collection_states;
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 0) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 1) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 2) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 3) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 4) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 5) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 6) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 7) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 8) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 9) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 10) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 11) + index_by];
+                csv << m_host_response[time_offset + (m_total_num_vehicles * 12) + index_by];
+                csv << std::endl;
+                steps_written++;
+            }
+        }
+    }
 }
 
 // ======================================================================================================================
 
-void d18SolverHalfImplicitGPU::WriteToFile() {
+__host__ void d18SolverHalfImplicitGPU::WriteToFile() {
     if (!m_output) {
         std::cout << "No output file specified. Call SetOutput() before calling WriteToFile()" << std::endl;
         return;
     }
-    m_csv.write_to_file(m_output_file);
-    m_csv.clearData();
-    m_timeStepsStored = 0;
+    unsigned int loop_limit = 0;
+    if (m_store_all) {
+        loop_limit = m_total_num_vehicles;
+    } else {
+        loop_limit = m_num_outs;
+    }
+    for (unsigned int sim_no = 0; sim_no < loop_limit; sim_no++) {
+        unsigned int index_by = 0;
+        // If we are no storing all, we will have to index by random numbers
+        if (m_store_all) {
+            index_by = sim_no;
+        } else {
+            index_by = m_which_outs[sim_no];
+        }
+        if (m_tire_type == TireType::TMeasy) {
+            CSV_writer& csv = m_sim_data[sim_no]._csv;
+            csv.write_to_file(m_output_file + "_" + std::to_string(index_by) + ".csv");
+            csv.clearData();
+        } else {
+            CSV_writer& csv = m_sim_data_nr[sim_no]._csv;
+            csv.write_to_file(m_output_file + "_" + std::to_string(index_by) + ".csv");
+            csv.clearData();
+        }
+    }
 }
 
 // ======================================================================================================================

--- a/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cu
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cu
@@ -1,0 +1,1336 @@
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <stdint.h>
+#include <vector>
+
+#include "dof18_gpu.cuh"
+#include "dof18_halfImplicit_gpu.cuh"
+
+using namespace d18;
+// ======================================================================================================================
+d18SolverHalfImplicitGPU::d18SolverHalfImplicitGPU(unsigned int total_num_vehicles)
+    : m_step(0.001), m_output(false), m_csv(" "), m_vehicle_count_tracker_params(0), m_vehicle_count_tracker_states(0) {
+    m_total_num_vehicles = total_num_vehicles;
+
+    // Allocate memory for the simData and simStates
+    CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_data, sizeof(d18::SimData) * m_total_num_vehicles));
+    CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_data_nr, sizeof(d18::SimDataNr) * m_total_num_vehicles));
+    CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_states, sizeof(d18::SimState) * m_total_num_vehicles));
+    CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_states_nr, sizeof(d18::SimStateNr) * m_total_num_vehicles));
+}
+d18SolverHalfImplicitGPU::~d18SolverHalfImplicitGPU() {
+    // Only need to delete the memory of the simData and simStates of the respective tire as the rest of the memory is
+    // freed as soon as we have information of what tire the user is using
+    if (m_tire_type == TireType::TMeasy) {
+        cudaFree(m_sim_data);
+        cudaFree(m_sim_states);
+        cudaFree(device_response);
+        delete[] host_response;
+    } else {
+        cudaFree(m_sim_data_nr);
+        cudaFree(m_sim_states_nr);
+        cudaFree(device_response_nr);
+        delete[] host_response_nr;
+    }
+}
+// ======================================================================================================================
+// Construct the solver using path to vehicle parameters, tire parameters, number of vehicles and driver
+__host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_params_file,
+                                                  const std::string& tire_params_file,
+                                                  unsigned int num_vehicles,
+                                                  const std::string& driver_inputs_file) {
+    // Check if num_vehicles added is less than the total number of vehicles
+    assert((num_vehicles + m_vehicle_count_tracker_params <= m_total_num_vehicles) &&
+           "Number of vehicles added makes the vehicle count greater than the total number of vehicles");
+    // If there is no tire type specified, then use TMeasy
+    m_tire_type = TireType::TMeasy;
+    // Because of this, we free the memory of the TMeasyNR tire
+    cudaFree(m_sim_data_nr);
+    cudaFree(m_sim_states_nr);
+    cudaFree(device_response_nr);
+    // Set these to nullptr so that we don't try to free them again in the destructor
+    m_sim_data_nr = nullptr;
+    m_sim_states_nr = nullptr;
+    device_response_nr = nullptr;
+
+    // Since cudaMallocManaged does not call the constructor for non-POD types, we create cpu structs and fill them up
+    // and then copy them over to the simData structs
+    d18::VehicleParam veh_param;
+    d18::TMeasyParam tire_param;
+
+    setVehParamsJSON(veh_param, vehicle_params_file.c_str());
+    setTireParamsJSON(tire_param, tire_params_file.c_str());
+    // Initialize tire parameters that depend on other parameters
+    tireInit(&tire_param);
+
+    DriverData driver_data;
+    LoadDriverData(driver_data, driver_inputs_file);
+    unsigned int driver_data_len = driver_data.size();
+    size_t old_vehicle_count = m_vehicle_count_tracker_params;
+    m_vehicle_count_tracker_params += num_vehicles;
+    for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_params; i++) {
+        m_sim_data[i]._driver_data_len = driver_data_len;
+        // Allocate memory for the driver data
+        CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_data[i]._driver_data,
+                                           sizeof(DriverInput) * m_sim_data[i]._driver_data_len));
+        // Copy the driver data from cpu to managed memory
+        std::copy(driver_data.begin(), driver_data.end(), m_sim_data[i]._driver_data);
+        // Fill up simulation data from the cpu structs
+        m_sim_data[i]._veh_param = veh_param;
+        m_sim_data[i]._tireTM_param = tire_param;
+        // Set the final integration time for each of the vehicles
+        m_sim_data[i]._t_end = driver_data.back().m_time;
+    }
+    cudaMemPrefetchAsync(&m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
+                         0);  // move the simData onto the GPU
+}
+
+__host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_params_file,
+                                                  const std::string& tire_params_file,
+                                                  unsigned int num_vehicles,
+                                                  const std::string& driver_inputs_file,
+                                                  TireType type) {
+    // Check if num_vehicles added is less than the total number of vehicles
+    assert((num_vehicles + m_vehicle_count_tracker_params <= m_total_num_vehicles) &&
+           "Number of vehicles added makes the vehicle count greater than the total number of vehicles");
+    // If there is no tire type specified, then use TMeasy
+    m_tire_type = type;
+
+    if (m_tire_type == TireType::TMeasy) {
+        // Because of this, we free the memory of the TMeasyNR tire
+        cudaFree(m_sim_data_nr);
+        cudaFree(m_sim_states_nr);
+        cudaFree(device_response_nr);
+        // Set these to nullptr so that we don't try to free them again in the destructor
+        m_sim_data_nr = nullptr;
+        m_sim_states_nr = nullptr;
+        device_response_nr = nullptr;
+
+        // Since cudaMallocManaged does not call the constructor for non-POD types, we create cpu structs and fill them
+        // up and then copy them over to the simData structs
+        d18::VehicleParam veh_param;
+        d18::TMeasyParam tire_param;
+
+        setVehParamsJSON(veh_param, vehicle_params_file.c_str());
+        setTireParamsJSON(tire_param, tire_params_file.c_str());
+        // Initialize tire parameters that depend on other parameters
+        tireInit(&tire_param);
+
+        DriverData driver_data;
+        LoadDriverData(driver_data, driver_inputs_file);
+        unsigned int driver_data_len = driver_data.size();
+        size_t old_vehicle_count = m_vehicle_count_tracker_params;
+        m_vehicle_count_tracker_params += num_vehicles;
+        for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_params; i++) {
+            m_sim_data[i]._driver_data_len = driver_data_len;
+            // Allocate memory for the driver data
+            CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_data[i]._driver_data,
+                                               sizeof(DriverInput) * m_sim_data[i]._driver_data_len));
+            // Copy the driver data from cpu to managed memory
+            std::copy(driver_data.begin(), driver_data.end(), m_sim_data[i]._driver_data);
+            // Fill up simulation data from the cpu structs
+            m_sim_data[i]._veh_param = veh_param;
+            m_sim_data[i]._tireTM_param = tire_param;
+            // Set the final integration time for each of the vehicles
+            m_sim_data[i]._t_end = driver_data.back().m_time;
+        }
+        cudaMemPrefetchAsync(&m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
+                             0);  // move the simData onto the GPU
+    } else {
+        // Because of this, we free the memory of the TMeasyNR tire
+        cudaFree(m_sim_data);
+        cudaFree(m_sim_states);
+        cudaFree(device_response);
+        // Set these to nullptr so that we don't try to free them again in the destructor
+        m_sim_data = nullptr;
+        m_sim_states = nullptr;
+        device_response = nullptr;
+
+        // Since cudaMallocManaged does not call the constructor for non-POD types, we create cpu structs and fill them
+        // up and then copy them over to the simData structs
+        d18::VehicleParam veh_param;
+        d18::TMeasyNrParam tire_param;
+
+        setVehParamsJSON(veh_param, vehicle_params_file.c_str());
+        setTireParamsJSON(tire_param, tire_params_file.c_str());
+        // Initialize tire parameters that depend on other parameters
+        tireInit(&tire_param);
+
+        DriverData driver_data;
+        LoadDriverData(driver_data, driver_inputs_file);
+        unsigned int driver_data_len = driver_data.size();
+        size_t old_vehicle_count = m_vehicle_count_tracker_params;
+        m_vehicle_count_tracker_params += num_vehicles;
+        for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_params; i++) {
+            m_sim_data_nr[i]._driver_data_len = driver_data_len;
+            // Allocate memory for the driver data
+            CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_data_nr[i]._driver_data,
+                                               sizeof(DriverInput) * m_sim_data_nr[i]._driver_data_len));
+            // Copy the driver data from cpu to managed memory
+            std::copy(driver_data.begin(), driver_data.end(), m_sim_data_nr[i]._driver_data);
+            // Fill up simulation data from the cpu structs
+            m_sim_data_nr[i]._veh_param = veh_param;
+            m_sim_data_nr[i]._tireTMNr_param = tire_param;
+            // Set the final integration time for each of the vehicles
+            m_sim_data_nr[i]._t_end = driver_data.back().m_time;
+        }
+        cudaMemPrefetchAsync(&m_sim_data_nr, sizeof(SimData) * m_vehicle_count_tracker_params,
+                             0);  // move the simData onto the GPU
+    }
+}
+
+// Overload for situations when a controller is used and we don't have a driver data file
+__host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_params_file,
+                                                  const std::string& tire_params_file,
+                                                  unsigned int num_vehicles) {
+    // Check if num_vehicles added is less than the total number of vehicles
+    assert((num_vehicles + m_vehicle_count_tracker_params <= m_total_num_vehicles) &&
+           "Number of vehicles added makes the vehicle count greater than the total number of vehicles");
+    // If there is no tire type specified, then use TMeasy
+    m_tire_type = TireType::TMeasy;
+    // Because of this, we free the memory of the TMeasyNR tire
+    cudaFree(m_sim_data_nr);
+    cudaFree(m_sim_states_nr);
+    cudaFree(device_response_nr);
+    // Set these to nullptr so that we don't try to free them again in the destructor
+    m_sim_data_nr = nullptr;
+    m_sim_states_nr = nullptr;
+    device_response_nr = nullptr;
+
+    // Since cudaMallocManaged does not call the constructor for non-POD types, we create cpu structs and fill them up
+    // and then copy them over to the simData structs
+    d18::VehicleParam veh_param;
+    d18::TMeasyParam tire_param;
+
+    setVehParamsJSON(veh_param, vehicle_params_file.c_str());
+    setTireParamsJSON(tire_param, tire_params_file.c_str());
+    // Initialize tire parameters that depend on other parameters
+    tireInit(&tire_param);
+
+    size_t old_vehicle_count = m_vehicle_count_tracker_params;
+    m_vehicle_count_tracker_params += num_vehicles;
+    for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_params; i++) {
+        // Fill up simulation data from the cpu structs
+        m_sim_data[i]._veh_param = veh_param;
+        m_sim_data[i]._tireTM_param = tire_param;
+    }
+
+    cudaMemPrefetchAsync(&m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
+                         0);  // move the simData onto the GPU
+}
+
+__host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_params_file,
+                                                  const std::string& tire_params_file,
+                                                  unsigned int num_vehicles,
+                                                  TireType type) {
+    // Check if num_vehicles added is less than the total number of vehicles
+    assert((num_vehicles + m_vehicle_count_tracker_params <= m_total_num_vehicles) &&
+           "Number of vehicles added makes the vehicle count greater than the total number of vehicles");
+    m_tire_type = type;
+    // If there is no tire type specified, then use TMeasy
+    if (m_tire_type == TireType::TMeasy) {
+        // Because of this, we free the memory of the TMeasyNR tire
+        cudaFree(m_sim_data_nr);
+        cudaFree(m_sim_states_nr);
+        cudaFree(device_response_nr);
+        // Set these to nullptr so that we don't try to free them again in the destructor
+        m_sim_data_nr = nullptr;
+        m_sim_states_nr = nullptr;
+        device_response_nr = nullptr;
+
+        // Since cudaMallocManaged does not call the constructor for non-POD types, we create cpu structs and fill them
+        // up and then copy them over to the simData structs
+        d18::VehicleParam veh_param;
+        d18::TMeasyParam tire_param;
+
+        setVehParamsJSON(veh_param, vehicle_params_file.c_str());
+        setTireParamsJSON(tire_param, tire_params_file.c_str());
+        // Initialize tire parameters that depend on other parameters
+        tireInit(&tire_param);
+
+        size_t old_vehicle_count = m_vehicle_count_tracker_params;
+        m_vehicle_count_tracker_params += num_vehicles;
+        for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_params; i++) {
+            // Fill up simulation data from the cpu structs
+            m_sim_data[i]._veh_param = veh_param;
+            m_sim_data[i]._tireTM_param = tire_param;
+        }
+        cudaMemPrefetchAsync(&m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
+                             0);  // move the simData onto the GPU
+    } else {
+        // Because of this, we free the memory of the TMeasyNR tire
+        cudaFree(m_sim_data);
+        cudaFree(m_sim_states);
+        cudaFree(device_response);
+        // Set these to nullptr so that we don't try to free them again in the destructor
+        m_sim_data = nullptr;
+        m_sim_states = nullptr;
+        device_response = nullptr;
+
+        // Since cudaMallocManaged does not call the constructor for non-POD types, we create cpu structs and fill them
+        // up and then copy them over to the simData structs
+        d18::VehicleParam veh_param;
+        d18::TMeasyNrParam tire_param;
+
+        setVehParamsJSON(veh_param, vehicle_params_file.c_str());
+        setTireParamsJSON(tire_param, tire_params_file.c_str());
+        // Initialize tire parameters that depend on other parameters
+        tireInit(&tire_param);
+
+        size_t old_vehicle_count = m_vehicle_count_tracker_params;
+        m_vehicle_count_tracker_params += num_vehicles;
+        for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_params; i++) {
+            // Fill up simulation data from the cpu structs
+            m_sim_data_nr[i]._veh_param = veh_param;
+            m_sim_data_nr[i]._tireTMNr_param = tire_param;
+        }
+        cudaMemPrefetchAsync(&m_sim_data_nr, sizeof(SimData) * m_vehicle_count_tracker_params,
+                             0);  // move the simData onto the GPU
+    }
+}
+// ======================================================================================================================
+
+__host__ void d18SolverHalfImplicitGPU::Initialize(d18::VehicleState& vehicle_states,
+                                                   d18::TMeasyState& tire_states_LF,
+                                                   d18::TMeasyState& tire_states_RF,
+                                                   d18::TMeasyState& tire_states_LR,
+                                                   d18::TMeasyState& tire_states_RR,
+                                                   unsigned int num_vehicles) {
+    // Esnure that construct was called with TMeasy tire type
+    assert((m_tire_type == TireType::TMeasy) &&
+           "Construct function called with TMeasyNr tire type, but Initialize called with TMeasy tire type");
+
+    size_t old_vehicle_count = m_vehicle_count_tracker_states;
+    m_vehicle_count_tracker_states += num_vehicles;
+    for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_states; i++) {
+        // Fill up simulation data from the cpu structs
+        m_sim_states[i]._veh_state = vehicle_states;
+        m_sim_states[i]._tirelf_state = tire_states_LF;
+        m_sim_states[i]._tirerf_state = tire_states_RF;
+        m_sim_states[i]._tirelr_state = tire_states_LR;
+        m_sim_states[i]._tirerr_state = tire_states_RR;
+    }
+    cudaMemPrefetchAsync(&m_sim_states, sizeof(SimState) * m_vehicle_count_tracker_states,
+                         0);  // move the simState onto the GPU
+
+    // TODO: Add Jacobian support
+    // // Size the jacobian matrices - size relies on the torque converter bool
+    // m_num_controls = 2;
+    // if (m_veh_param._tcbool) {
+    //     m_num_states = 21;
+    //     m_jacobian_state.resize(m_num_states, std::vector<double>(m_num_states, 0));
+    //     m_jacobian_controls.resize(m_num_states, std::vector<double>(m_num_controls, 0));
+    // } else {
+    //     m_num_states = 20;
+    //     m_jacobian_state.resize(m_num_states, std::vector<double>(m_num_states, 0));
+    //     m_jacobian_controls.resize(m_num_states, std::vector<double>(m_num_controls, 0));
+    // }
+}
+
+// TMeasy without relaxation does not have tire states and so the jacobian size reduces by 8
+__host__ void d18SolverHalfImplicitGPU::Initialize(d18::VehicleState& vehicle_states,
+                                                   d18::TMeasyNrState& tire_states_LF,
+                                                   d18::TMeasyNrState& tire_states_RF,
+                                                   d18::TMeasyNrState& tire_states_LR,
+                                                   d18::TMeasyNrState& tire_states_RR,
+                                                   unsigned int num_vehicles) {
+    // Esnure that construct was called with TMeasyNr tire type
+    assert((m_tire_type == TireType::TMeasyNr) &&
+           "Construct function called with TMeasy tire type, but Initialize called with TMeasyNR tire type");
+    size_t old_vehicle_count = m_vehicle_count_tracker_states;
+    m_vehicle_count_tracker_states += num_vehicles;
+    for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_states; i++) {
+        // Fill up simulation data from the cpu structs
+        m_sim_states_nr[i]._veh_state = vehicle_states;
+        m_sim_states_nr[i]._tirelf_state = tire_states_LF;
+        m_sim_states_nr[i]._tirerf_state = tire_states_RF;
+        m_sim_states_nr[i]._tirelr_state = tire_states_LR;
+        m_sim_states_nr[i]._tirerr_state = tire_states_RR;
+    }
+    cudaMemPrefetchAsync(&m_sim_states_nr, sizeof(SimState) * m_vehicle_count_tracker_states,
+                         0);  // move the simState onto the GPU
+
+    // TODO: Add Jacobian support
+    // Size the jacobian matrices - size relies on the torque converter bool
+    // m_num_controls = 2;
+    // if (m_veh_param._tcbool) {
+    //     m_num_states = 13;
+    //     m_jacobian_state.resize(m_num_states, std::vector<double>(m_num_states, 0));
+    //     m_jacobian_controls.resize(m_num_states, std::vector<double>(m_num_controls, 0));
+    // } else {
+    //     m_num_states = 12;
+    //     m_jacobian_state.resize(m_num_states, std::vector<double>(m_num_states, 0));
+    //     m_jacobian_controls.resize(m_num_states, std::vector<double>(m_num_controls, 0));
+    // }
+}
+
+// ======================================================================================================================
+
+/// @brief Sets the path for the output file
+/// @param output_file string with full path with extension
+void d18SolverHalfImplicitGPU::SetOutput(const std::string& output_file, double output_freq) {
+    m_output = true;
+    m_output_file = output_file;
+    m_timeStepsStored = 0;
+    m_dtout = 1.0 / output_freq;
+}
+
+// ======================================================================================================================
+
+/// @brief Solve the system of equations by calling the integrate function
+void d18SolverHalfImplicitGPU::Solve() {
+    assert(!m_driver_data.empty() && "No controls provided, please use construct to pass path to driver inputs");
+
+    // For now just integrate to final time
+    Integrate();
+}
+
+// ======================================================================================================================
+
+/// @brief Integrate the system of equations using the half implicit method - Calls the RHS function at each time step
+void d18SolverHalfImplicitGPU::Integrate() {
+    double t = 0;
+    // Create output writer
+    if (m_output) {
+        Write(t);
+        m_timeStepsStored++;
+    }
+
+    // Integrate to final time by repeatedly calling the RHS function
+    while (t < (m_tend - m_step / 10.)) {
+        // Call RHS to get all accelerations
+        rhsFun(t);
+
+        // Integrate according to half implicit method for second order states
+        // Integrate according to explicit method for first order states
+
+        if (m_tire_type == TireType::TMeasy) {  // Only TM easy has xe and ye states
+            // First the tire states
+            // LF
+            m_tireTMlf_state._xe += m_tireTMlf_state._xedot * m_step;
+            m_tireTMlf_state._ye += m_tireTMlf_state._yedot * m_step;
+            m_tireTMlf_state._omega += m_tireTMlf_state._dOmega * m_step;
+            // RF
+            m_tireTMrf_state._xe += m_tireTMrf_state._xedot * m_step;
+            m_tireTMrf_state._ye += m_tireTMrf_state._yedot * m_step;
+            m_tireTMrf_state._omega += m_tireTMrf_state._dOmega * m_step;
+            // LR
+            m_tireTMlr_state._xe += m_tireTMlr_state._xedot * m_step;
+            m_tireTMlr_state._ye += m_tireTMlr_state._yedot * m_step;
+            m_tireTMlr_state._omega += m_tireTMlr_state._dOmega * m_step;
+            // RR
+            m_tireTMrr_state._xe += m_tireTMrr_state._xedot * m_step;
+            m_tireTMrr_state._ye += m_tireTMrr_state._yedot * m_step;
+            m_tireTMrr_state._omega += m_tireTMrr_state._dOmega * m_step;
+        } else {  // Other tires have only omega states
+            // First the tire states
+            // LF
+            m_tireTMNrlf_state._omega += m_tireTMNrlf_state._dOmega * m_step;
+            // RF
+            m_tireTMNrrf_state._omega += m_tireTMNrrf_state._dOmega * m_step;
+            // LR
+            m_tireTMNrlr_state._omega += m_tireTMNrlr_state._dOmega * m_step;
+            // RR
+            m_tireTMNrrr_state._omega += m_tireTMNrrr_state._dOmega * m_step;
+        }
+
+        // Now the vehicle states
+        if (m_veh_param._tcbool) {
+            m_veh_state._crankOmega += m_veh_state._dOmega_crank * m_step;
+        }
+
+        // Integrate velocity level first
+        m_veh_state._u += m_veh_state._udot * m_step;
+        m_veh_state._v += m_veh_state._vdot * m_step;
+        m_veh_state._wx += m_veh_state._wxdot * m_step;
+        m_veh_state._wz += m_veh_state._wzdot * m_step;
+
+        // Integrate position level next
+        m_veh_state._x +=
+            (m_veh_state._u * std::cos(m_veh_state._psi) - m_veh_state._v * std::sin(m_veh_state._psi)) * m_step;
+        m_veh_state._y +=
+            (m_veh_state._u * std::sin(m_veh_state._psi) + m_veh_state._v * std::cos(m_veh_state._psi)) * m_step;
+        m_veh_state._psi += m_veh_state._wz * m_step;
+        m_veh_state._phi += m_veh_state._wx * m_step;
+
+        // Update time
+        t += m_step;
+
+        // Write the output
+        if (m_output) {
+            if (std::abs(t - m_timeStepsStored * m_dtout) < 1e-7) {
+                Write(t);
+                m_timeStepsStored++;
+            }
+        }
+    }
+    if (m_output) {
+        WriteToFile();
+    }
+}
+// ======================================================================================================================
+
+/// @brief Function call to integrate by just a single time step. This function will always integrate to the t + m_step
+/// where m_step is set using the SetTimeStep function.
+/// @param t current time
+/// @param throttle throttle input
+/// @param steering steering input
+/// @param braking braking input
+/// @return t + m_step
+double d18SolverHalfImplicitGPU::IntegrateStep(double t, double throttle, double steering, double braking) {
+    // Store header and first time step
+    if (m_output && (t < m_step)) {
+        Write(t);
+        m_timeStepsStored++;
+    }
+
+    DriverInput controls(t, steering, throttle, braking);
+    // Call the RHS function
+    rhsFun(t, controls);
+
+    // Integrate according to half implicit method for second order states
+    // Integrate according to explicit method for first order states
+
+    if (m_tire_type == TireType::TMeasy) {  // Only TM easy has xe and ye states
+        // First the tire states
+        // LF
+        m_tireTMlf_state._xe += m_tireTMlf_state._xedot * m_step;
+        m_tireTMlf_state._ye += m_tireTMlf_state._yedot * m_step;
+        m_tireTMlf_state._omega += m_tireTMlf_state._dOmega * m_step;
+        // RF
+        m_tireTMrf_state._xe += m_tireTMrf_state._xedot * m_step;
+        m_tireTMrf_state._ye += m_tireTMrf_state._yedot * m_step;
+        m_tireTMrf_state._omega += m_tireTMrf_state._dOmega * m_step;
+        // LR
+        m_tireTMlr_state._xe += m_tireTMlr_state._xedot * m_step;
+        m_tireTMlr_state._ye += m_tireTMlr_state._yedot * m_step;
+        m_tireTMlr_state._omega += m_tireTMlr_state._dOmega * m_step;
+        // RR
+        m_tireTMrr_state._xe += m_tireTMrr_state._xedot * m_step;
+        m_tireTMrr_state._ye += m_tireTMrr_state._yedot * m_step;
+        m_tireTMrr_state._omega += m_tireTMrr_state._dOmega * m_step;
+    } else {  // Other tires have only omega states
+        // First the tire states
+        // LF
+        m_tireTMNrlf_state._omega += m_tireTMNrlf_state._dOmega * m_step;
+        // RF
+        m_tireTMNrrf_state._omega += m_tireTMNrrf_state._dOmega * m_step;
+        // LR
+        m_tireTMNrlr_state._omega += m_tireTMNrlr_state._dOmega * m_step;
+        // RR
+        m_tireTMNrrr_state._omega += m_tireTMNrrr_state._dOmega * m_step;
+    }
+
+    // Now the vehicle states
+    if (m_veh_param._tcbool) {
+        m_veh_state._crankOmega += m_veh_state._dOmega_crank * m_step;
+    }
+
+    // Integrate velocity level first
+    m_veh_state._u += m_veh_state._udot * m_step;
+    m_veh_state._v += m_veh_state._vdot * m_step;
+    m_veh_state._wx += m_veh_state._wxdot * m_step;
+    m_veh_state._wz += m_veh_state._wzdot * m_step;
+
+    // Integrate position level next
+    m_veh_state._x +=
+        (m_veh_state._u * std::cos(m_veh_state._psi) - m_veh_state._v * std::sin(m_veh_state._psi)) * m_step;
+    m_veh_state._y +=
+        (m_veh_state._u * std::sin(m_veh_state._psi) + m_veh_state._v * std::cos(m_veh_state._psi)) * m_step;
+    m_veh_state._psi += m_veh_state._wz * m_step;
+    m_veh_state._phi += m_veh_state._wx * m_step;
+
+    double new_time = t + m_step;
+    // Write the output
+    if (m_output) {
+        if (std::abs(new_time - m_timeStepsStored * m_dtout) < 1e-7) {
+            Write(new_time);
+            m_timeStepsStored++;
+        }
+    }
+
+    return new_time;
+}
+// ======================================================================================================================
+/// @brief Function call to integrate by just a single time step with jacobian computation. The order of the states in
+// the jacobian matrix if the TMeasy tire is used are is as follows:
+//  0: tirelf_st._xe;
+//  1: tirelf_st._ye;
+//  2: tirerf_st._xe;
+//  3: tirerf_st._ye;
+//  4: tirelr_st._xe;
+//  5: tirelr_st._ye;
+//  6: tirerr_st._xe;
+//  7: tirerr_st._ye;
+//  8: tirelf_st._omega;
+//  9: tirerf_st._omega;
+//  10: tirelr_st._omega;
+//  11: tirerr_st._omega;
+//  12: v_states._crankOmega; (only if torque converter is used)
+//  13: v_states._x;
+//  14: v_states._y;
+//  15: v_states._u;
+//  16: v_states._v;
+//  17: v_states._psi;
+//  18: v_states._wz;
+//  19: v_states._phi;
+//  20: v_states._wx;
+// If the TMeasyNR tire is used then the order of the states in the jacobian matrix are as follows:
+//  0: tirelf_st._omega;
+//  1: tirerf_st._omega;
+//  2: tirelr_st._omega;
+//  3: tirerr_st._omega;
+//  4: v_states._crankOmega; (only if torque converter is used)
+//  5: v_states._x;
+//  6: v_states._y;
+//  7: v_states._u;
+//  8: v_states._v;
+//  9: v_states._psi;
+//  10: v_states._wz;
+//  11: v_states._phi;
+//  12: v_states._wx;
+/// @param t current time
+/// @param throttle throttle input
+/// @param steering steering input
+/// @param braking braking input
+/// @param on boolean to turn on jacobian computation
+/// @return t + m_step
+double d18SolverHalfImplicitGPU::IntegrateStepWithJacobian(double t,
+                                                           double throttle,
+                                                           double steering,
+                                                           double braking,
+                                                           bool jacOn) {
+    // Store header and first time step
+    if (m_output && (t < m_step)) {
+        Write(t);
+        m_timeStepsStored++;
+    }
+
+    DriverInput controls(t, steering, throttle, braking);
+
+    // If the jacobian switch is on, then compute the jacobian
+    if (jacOn) {
+        std::vector<double> y(m_num_states, 0);
+        std::vector<double> ydot(m_num_states, 0);
+        // package all the current states
+        if (m_tire_type == TireType::TMeasy) {
+            packY(m_veh_state, m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state,
+                  m_veh_param._tcbool, y);
+        } else {
+            packY(m_veh_state, m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state, m_tireTMNrrr_state,
+                  m_veh_param._tcbool, y);
+        }
+
+        // ============================
+        // Computing the state jacobian
+        // ============================
+
+        // Set a vector of del Ys - for now set this to some scale of y
+        std::vector<double> delY(y.begin(), y.end());
+        // In a loop pertub each state and get the corresponding perturbed ydot
+        int ySize = y.size();
+
+#pragma omp parallel for simd
+        for (int i = 0; i < ySize; i++) {
+            // Perterbation is 1e-3 * y (since some states are really small values wile some are huge)
+            delY[i] = std::abs(delY[i] * 1e-3);
+            if (delY[i] < 1e-8) {
+                // This means that the particular state is 0. In this case set dels to 1e-3
+                delY[i] = 1e-3;
+            }
+
+            // perturb y at i
+            std::vector<double> perturbedYPlus(y.begin(), y.end());
+            std::vector<double> perturbedYMinus(y.begin(), y.end());
+
+            perturbedYPlus[i] = perturbedYPlus[i] + delY[i];
+            perturbedYMinus[i] = perturbedYMinus[i] - delY[i];
+
+            // ydots to store the output
+            std::vector<double> ydotPlus(y.size(), 0.);
+            std::vector<double> ydotMinus(y.size(), 0.);
+
+            // Call the perturb function with these to get the perturbed ydot -> This does not update the state
+            PerturbRhsFun(perturbedYPlus, controls, ydotPlus);
+            PerturbRhsFun(perturbedYMinus, controls, ydotMinus);
+
+// Update the jacobian matrix
+#pragma omp simd
+            for (int j = 0; j < ySize; j++) {
+                m_jacobian_state[j][i] = (ydotPlus[j] - ydotMinus[j]) / (2 * delY[i]);
+            }
+        }
+
+        // ==============================
+        // Computing the control jacobian
+        //===============================
+
+        // Set a vector of del controls - for now we ingnore braking
+        std::vector<double> delControls = {1e-3, 1e-3};
+        // In a loop pertub each control and get the corresponding perturbed ydot
+        int controlSize = delControls.size();
+
+        for (int i = 0; i < controlSize; i++) {
+            // perturb controls at i
+            std::vector<double> perturbedControlsPlus = {steering, throttle};
+            std::vector<double> perturbedControlsMinus = {steering, throttle};
+
+            perturbedControlsPlus[i] = perturbedControlsPlus[i] + delControls[i];
+            perturbedControlsMinus[i] = perturbedControlsMinus[i] - delControls[i];
+
+            // ydots to store the output
+            std::vector<double> ydotPlus(y.size(), 0.);
+            std::vector<double> ydotMinus(y.size(), 0.);
+
+            // Call the perturb function with these to get the perturbed ydot -> This does not update the state
+            DriverInput inputPlus(t, perturbedControlsPlus[0], perturbedControlsPlus[1], 0);
+            DriverInput inputMinus(t, perturbedControlsMinus[0], perturbedControlsMinus[1], 0);
+            PerturbRhsFun(y, inputPlus, ydotPlus);
+            PerturbRhsFun(y, inputMinus, ydotMinus);
+
+            // Update the jacobian matrix
+            for (int j = 0; j < ySize; j++) {
+                m_jacobian_controls[j][i] = (ydotPlus[j] - ydotMinus[j]) / (2 * delControls[i]);
+            }
+        }
+    }
+
+    // Call the RHS function
+    rhsFun(t, controls);
+
+    // Integrate according to half implicit method for second order states
+    // Integrate according to explicit method for first order states
+
+    if (m_tire_type == TireType::TMeasy) {  // Only TM easy has xe and ye states
+        // First the tire states
+        // LF
+        m_tireTMlf_state._xe += m_tireTMlf_state._xedot * m_step;
+        m_tireTMlf_state._ye += m_tireTMlf_state._yedot * m_step;
+        m_tireTMlf_state._omega += m_tireTMlf_state._dOmega * m_step;
+        // RF
+        m_tireTMrf_state._xe += m_tireTMrf_state._xedot * m_step;
+        m_tireTMrf_state._ye += m_tireTMrf_state._yedot * m_step;
+        m_tireTMrf_state._omega += m_tireTMrf_state._dOmega * m_step;
+        // LR
+        m_tireTMlr_state._xe += m_tireTMlr_state._xedot * m_step;
+        m_tireTMlr_state._ye += m_tireTMlr_state._yedot * m_step;
+        m_tireTMlr_state._omega += m_tireTMlr_state._dOmega * m_step;
+        // RR
+        m_tireTMrr_state._xe += m_tireTMrr_state._xedot * m_step;
+        m_tireTMrr_state._ye += m_tireTMrr_state._yedot * m_step;
+        m_tireTMrr_state._omega += m_tireTMrr_state._dOmega * m_step;
+    } else {  // Other tires have only omega states
+        // First the tire states
+        // LF
+        m_tireTMNrlf_state._omega += m_tireTMNrlf_state._dOmega * m_step;
+        // RF
+        m_tireTMNrrf_state._omega += m_tireTMNrrf_state._dOmega * m_step;
+        // LR
+        m_tireTMNrlr_state._omega += m_tireTMNrlr_state._dOmega * m_step;
+        // RR
+        m_tireTMNrrr_state._omega += m_tireTMNrrr_state._dOmega * m_step;
+    }
+    // Now the vehicle states
+    if (m_veh_param._tcbool) {
+        m_veh_state._crankOmega += m_veh_state._dOmega_crank * m_step;
+    }
+
+    // Integrate velocity level first
+    m_veh_state._u += m_veh_state._udot * m_step;
+    m_veh_state._v += m_veh_state._vdot * m_step;
+    m_veh_state._wx += m_veh_state._wxdot * m_step;
+    m_veh_state._wz += m_veh_state._wzdot * m_step;
+
+    // Integrate position level next
+    m_veh_state._x +=
+        (m_veh_state._u * std::cos(m_veh_state._psi) - m_veh_state._v * std::sin(m_veh_state._psi)) * m_step;
+    m_veh_state._y +=
+        (m_veh_state._u * std::sin(m_veh_state._psi) + m_veh_state._v * std::cos(m_veh_state._psi)) * m_step;
+    m_veh_state._psi += m_veh_state._wz * m_step;
+    m_veh_state._phi += m_veh_state._wx * m_step;
+
+    double new_time = t + m_step;
+    // Write the output
+    if (m_output) {
+        if (std::abs(new_time - m_timeStepsStored * m_dtout) < 1e-7) {
+            Write(new_time);
+            m_timeStepsStored++;
+        }
+    }
+
+    return new_time;
+}
+
+// ======================================================================================================================
+
+/// @brief Computes the RHS of all the ODEs (tire velocities, chassis accelerations)
+/// @param t Current time
+void d18SolverHalfImplicitGPU::rhsFun(double t) {
+    // Get controls at the current timeStep
+    auto controls = GetDriverInput(t, m_driver_data);
+
+    // Calculate tire vertical loads
+    std::vector<double> loads(4, 0);
+    if (m_tire_type == TireType::TMeasy) {
+        computeTireLoads(loads, m_veh_state, m_veh_param, m_tireTM_param);
+
+        // Transform from vehicle frame to the tire frame
+        vehToTireTransform(m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state, m_veh_state, loads,
+                           m_veh_param, controls.m_steering);
+
+        // Tire velocities using TMEasy tire
+        computeTireRHS(m_tireTMlf_state, m_tireTM_param, m_veh_param, controls.m_steering);
+        computeTireRHS(m_tireTMrf_state, m_tireTM_param, m_veh_param, controls.m_steering);
+        computeTireRHS(m_tireTMlr_state, m_tireTM_param, m_veh_param, 0);  // No rear steering
+        computeTireRHS(m_tireTMrr_state, m_tireTM_param, m_veh_param, 0);  // No rear steering
+
+        // Powertrain dynamics
+        computePowertrainRHS(m_veh_state, m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state,
+                             m_veh_param, m_tireTM_param, controls);
+//////// DEBUG
+#ifdef DEBUG
+        M_DEBUG_LF_TIRE_FX = m_tireTMlf_state._fx;
+        M_DEBUG_RF_TIRE_FX = m_tireTMrf_state._fx;
+        M_DEBUG_LR_TIRE_FX = m_tireTMlr_state._fx;
+        M_DEBUG_RR_TIRE_FX = m_tireTMrr_state._fx;
+
+        M_DEBUG_LF_TIRE_FY = m_tireTMlf_state._fy;
+        M_DEBUG_RF_TIRE_FY = m_tireTMrf_state._fy;
+        M_DEBUG_LR_TIRE_FY = m_tireTMlr_state._fy;
+        M_DEBUG_RR_TIRE_FY = m_tireTMrr_state._fy;
+
+        M_DEBUG_LF_TIRE_FZ = m_tireTMlf_state._fz;
+        M_DEBUG_RF_TIRE_FZ = m_tireTMrf_state._fz;
+        M_DEBUG_LR_TIRE_FZ = m_tireTMlr_state._fz;
+        M_DEBUG_RR_TIRE_FZ = m_tireTMrr_state._fz;
+#endif
+
+        // Vehicle dynamics
+        tireToVehTransform(m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state, m_veh_state,
+                           m_veh_param, controls.m_steering);
+        std::vector<double> fx = {m_tireTMlf_state._fx, m_tireTMrf_state._fx, m_tireTMlr_state._fx,
+                                  m_tireTMrr_state._fx};
+        std::vector<double> fy = {m_tireTMlf_state._fy, m_tireTMrf_state._fy, m_tireTMlr_state._fy,
+                                  m_tireTMrr_state._fy};
+        computeVehRHS(m_veh_state, m_veh_param, fx, fy);
+    } else {  // For the other tire
+        computeTireLoads(loads, m_veh_state, m_veh_param, m_tireTMNr_param);
+
+        // Transform from vehicle frame to the tire frame
+        vehToTireTransform(m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state, m_tireTMNrrr_state, m_veh_state,
+                           loads, m_veh_param, controls.m_steering);
+
+        // Tire velocities using TMEasy tire
+        computeTireRHS(m_tireTMNrlf_state, m_tireTMNr_param, m_veh_param, controls.m_steering);
+        computeTireRHS(m_tireTMNrrf_state, m_tireTMNr_param, m_veh_param, controls.m_steering);
+        computeTireRHS(m_tireTMNrlr_state, m_tireTMNr_param, m_veh_param, 0);  // No rear steering
+        computeTireRHS(m_tireTMNrrr_state, m_tireTMNr_param, m_veh_param, 0);  // No rear steering
+
+        // Powertrain dynamics
+        computePowertrainRHS(m_veh_state, m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state,
+                             m_tireTMNrrr_state, m_veh_param, m_tireTMNr_param, controls);
+//////// DEBUG
+#ifdef DEBUG
+        M_DEBUG_LF_TIRE_FX = m_tireTMNrlf_state._fx;
+        M_DEBUG_RF_TIRE_FX = m_tireTMNrrf_state._fx;
+        M_DEBUG_LR_TIRE_FX = m_tireTMNrlr_state._fx;
+        M_DEBUG_RR_TIRE_FX = m_tireTMNrrr_state._fx;
+
+        M_DEBUG_LF_TIRE_FY = m_tireTMNrlf_state._fy;
+        M_DEBUG_RF_TIRE_FY = m_tireTMNrrf_state._fy;
+        M_DEBUG_LR_TIRE_FY = m_tireTMNrlr_state._fy;
+        M_DEBUG_RR_TIRE_FY = m_tireTMNrrr_state._fy;
+
+        M_DEBUG_LF_TIRE_FZ = m_tireTMNrlf_state._fz;
+        M_DEBUG_RF_TIRE_FZ = m_tireTMNrrf_state._fz;
+        M_DEBUG_LR_TIRE_FZ = m_tireTMNrlr_state._fz;
+        M_DEBUG_RR_TIRE_FZ = m_tireTMNrrr_state._fz;
+#endif
+
+        // Vehicle dynamics
+        tireToVehTransform(m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state, m_tireTMNrrr_state, m_veh_state,
+                           m_veh_param, controls.m_steering);
+        std::vector<double> fx = {m_tireTMNrlf_state._fx, m_tireTMNrrf_state._fx, m_tireTMNrlr_state._fx,
+                                  m_tireTMNrrr_state._fx};
+        std::vector<double> fy = {m_tireTMNrlf_state._fy, m_tireTMNrrf_state._fy, m_tireTMNrlr_state._fy,
+                                  m_tireTMNrrr_state._fy};
+        computeVehRHS(m_veh_state, m_veh_param, fx, fy);
+    }
+}
+
+// ======================================================================================================================
+
+void d18SolverHalfImplicitGPU::rhsFun(double t, DriverInput& controls) {
+    // Calculate tire vertical loads
+    std::vector<double> loads(4, 0);
+    if (m_tire_type == TireType::TMeasy) {
+        computeTireLoads(loads, m_veh_state, m_veh_param, m_tireTM_param);
+
+        // Transform from vehicle frame to the tire frame
+        vehToTireTransform(m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state, m_veh_state, loads,
+                           m_veh_param, controls.m_steering);
+
+        // Tire velocities using TMEasy tire
+        computeTireRHS(m_tireTMlf_state, m_tireTM_param, m_veh_param, controls.m_steering);
+        computeTireRHS(m_tireTMrf_state, m_tireTM_param, m_veh_param, controls.m_steering);
+        computeTireRHS(m_tireTMlr_state, m_tireTM_param, m_veh_param, 0);  // No rear steering
+        computeTireRHS(m_tireTMrr_state, m_tireTM_param, m_veh_param, 0);  // No rear steering
+
+        // Powertrain dynamics
+        computePowertrainRHS(m_veh_state, m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state,
+                             m_veh_param, m_tireTM_param, controls);
+
+        // Vehicle dynamics
+        tireToVehTransform(m_tireTMlf_state, m_tireTMrf_state, m_tireTMlr_state, m_tireTMrr_state, m_veh_state,
+                           m_veh_param, controls.m_steering);
+        std::vector<double> fx = {m_tireTMlf_state._fx, m_tireTMrf_state._fx, m_tireTMlr_state._fx,
+                                  m_tireTMrr_state._fx};
+        std::vector<double> fy = {m_tireTMlf_state._fy, m_tireTMrf_state._fy, m_tireTMlr_state._fy,
+                                  m_tireTMrr_state._fy};
+        computeVehRHS(m_veh_state, m_veh_param, fx, fy);
+    } else {  // For the other tire
+        computeTireLoads(loads, m_veh_state, m_veh_param, m_tireTMNr_param);
+
+        // Transform from vehicle frame to the tire frame
+        vehToTireTransform(m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state, m_tireTMNrrr_state, m_veh_state,
+                           loads, m_veh_param, controls.m_steering);
+
+        // Tire velocities using TMEasy tire
+        computeTireRHS(m_tireTMNrlf_state, m_tireTMNr_param, m_veh_param, controls.m_steering);
+        computeTireRHS(m_tireTMNrrf_state, m_tireTMNr_param, m_veh_param, controls.m_steering);
+        computeTireRHS(m_tireTMNrlr_state, m_tireTMNr_param, m_veh_param, 0);  // No rear steering
+        computeTireRHS(m_tireTMNrrr_state, m_tireTMNr_param, m_veh_param, 0);  // No rear steering
+
+        // Powertrain dynamics
+        computePowertrainRHS(m_veh_state, m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state,
+                             m_tireTMNrrr_state, m_veh_param, m_tireTMNr_param, controls);
+
+        // Vehicle dynamics
+        tireToVehTransform(m_tireTMNrlf_state, m_tireTMNrrf_state, m_tireTMNrlr_state, m_tireTMNrrr_state, m_veh_state,
+                           m_veh_param, controls.m_steering);
+        std::vector<double> fx = {m_tireTMNrlf_state._fx, m_tireTMNrrf_state._fx, m_tireTMNrlr_state._fx,
+                                  m_tireTMNrrr_state._fx};
+        std::vector<double> fy = {m_tireTMNrlf_state._fy, m_tireTMNrrf_state._fy, m_tireTMNrlr_state._fy,
+                                  m_tireTMNrrr_state._fy};
+        computeVehRHS(m_veh_state, m_veh_param, fx, fy);
+    }
+}
+
+// ======================================================================================================================
+
+// Function takes (y +- dely) and provides a new ydot for the pertubed y (ydot is the rhs of the system of equations)
+
+void d18SolverHalfImplicitGPU::PerturbRhsFun(std::vector<double>& y, DriverInput& controls, std::vector<double>& ydot) {
+    // Extract the vehicle and tire states vector state
+    VehicleState veh_st;
+    if (m_tire_type == TireType::TMeasy) {
+        TMeasyState tirelf_st;
+        TMeasyState tirerf_st;
+        TMeasyState tirelr_st;
+        TMeasyState tirerr_st;
+        unpackY(y, m_veh_param._tcbool, veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st);
+
+        // Calculate tire vertical loads
+        std::vector<double> loads(4, 0);
+        computeTireLoads(loads, veh_st, m_veh_param, m_tireTM_param);
+
+        // Transform from the vehicle frame to the tire frame
+        vehToTireTransform(tirelf_st, tirerf_st, tirelr_st, tirerr_st, veh_st, loads, m_veh_param, controls.m_steering);
+
+        // Tire dynamics
+        computeTireRHS(tirelf_st, m_tireTM_param, m_veh_param, controls.m_steering);
+        computeTireRHS(tirerf_st, m_tireTM_param, m_veh_param, controls.m_steering);
+        computeTireRHS(tirelr_st, m_tireTM_param, m_veh_param, 0);
+        computeTireRHS(tirerr_st, m_tireTM_param, m_veh_param, 0);
+
+        // Powertrain dynamics
+        computePowertrainRHS(veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st, m_veh_param, m_tireTM_param, controls);
+
+        // Vehicle dynamics
+        tireToVehTransform(tirelf_st, tirerf_st, tirelr_st, tirerr_st, veh_st, m_veh_param, controls.m_steering);
+        std::vector<double> fx = {tirelf_st._fx, tirerf_st._fx, tirelr_st._fx, tirerr_st._fx};
+        std::vector<double> fy = {tirelf_st._fy, tirerf_st._fy, tirelr_st._fy, tirerr_st._fy};
+        computeVehRHS(veh_st, m_veh_param, fx, fy);
+
+        // Pack the ydot and send it
+        packYDOT(veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st, m_veh_param._tcbool, ydot);
+    } else {
+        TMeasyNrState tirelf_st;
+        TMeasyNrState tirerf_st;
+        TMeasyNrState tirelr_st;
+        TMeasyNrState tirerr_st;
+        unpackY(y, m_veh_param._tcbool, veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st);
+
+        // Calculate tire vertical loads
+        std::vector<double> loads(4, 0);
+        computeTireLoads(loads, veh_st, m_veh_param, m_tireTMNr_param);
+
+        // Transform from the vehicle frame to the tire frame
+        vehToTireTransform(tirelf_st, tirerf_st, tirelr_st, tirerr_st, veh_st, loads, m_veh_param, controls.m_steering);
+
+        // Tire dynamics
+        computeTireRHS(tirelf_st, m_tireTMNr_param, m_veh_param, controls.m_steering);
+        computeTireRHS(tirerf_st, m_tireTMNr_param, m_veh_param, controls.m_steering);
+        computeTireRHS(tirelr_st, m_tireTMNr_param, m_veh_param, 0);
+        computeTireRHS(tirerr_st, m_tireTMNr_param, m_veh_param, 0);
+
+        // Powertrain dynamics
+        computePowertrainRHS(veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st, m_veh_param, m_tireTMNr_param,
+                             controls);
+
+        // Vehicle dynamics
+        tireToVehTransform(tirelf_st, tirerf_st, tirelr_st, tirerr_st, veh_st, m_veh_param, controls.m_steering);
+        std::vector<double> fx = {tirelf_st._fx, tirerf_st._fx, tirelr_st._fx, tirerr_st._fx};
+        std::vector<double> fy = {tirelf_st._fy, tirerf_st._fy, tirelr_st._fy, tirerr_st._fy};
+        computeVehRHS(veh_st, m_veh_param, fx, fy);
+
+        // Pack the ydot and send it
+        packYDOT(veh_st, tirelf_st, tirerf_st, tirelr_st, tirerr_st, m_veh_param._tcbool, ydot);
+    }
+}
+
+void d18SolverHalfImplicitGPU::Write(double t) {
+    // If we are in initial time step, write the header
+    if (t < m_step) {
+        m_csv << "time";
+        m_csv << "x";
+        m_csv << "y";
+        m_csv << "vx";
+        m_csv << "vy";
+        m_csv << "ax";
+        m_csv << "ay";
+        m_csv << "roll";
+        m_csv << "yaw";
+        m_csv << "roll_rate";
+        m_csv << "yaw_rate";
+        m_csv << "wlf";
+        m_csv << "wrf";
+        m_csv << "wlr";
+        m_csv << "wrr";
+        m_csv << "sp_tor";
+        m_csv << "current_gear";
+        m_csv << "engine_omega";
+#ifdef DEBUG
+        m_csv << "lf_tireForce_x";
+        m_csv << "rf_tireForce_x";
+        m_csv << "lr_tireForce_x";
+        m_csv << "rr_tireForce_x";
+        m_csv << "lf_tireForce_y";
+        m_csv << "rf_tireForce_y";
+        m_csv << "lr_tireForce_y";
+        m_csv << "rr_tireForce_y";
+        m_csv << "lf_tireForce_z";
+        m_csv << "rf_tireForce_z";
+        m_csv << "lr_tireForce_z";
+        m_csv << "rr_tireForce_z";
+#endif
+        m_csv << std::endl;
+
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+#ifdef DEBUG
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+        m_csv << 0;
+#endif
+        m_csv << std::endl;
+        return;
+    }
+
+    m_csv << t;
+    m_csv << m_veh_state._x;
+    m_csv << m_veh_state._y;
+    m_csv << m_veh_state._u;
+    m_csv << m_veh_state._v;
+    m_csv << m_veh_state._udot;
+    m_csv << m_veh_state._vdot;
+    m_csv << m_veh_state._phi;
+    m_csv << m_veh_state._psi;
+    m_csv << m_veh_state._wx;
+    m_csv << m_veh_state._wz;
+    if (m_tire_type == TireType::TMeasy) {
+        m_csv << m_tireTMlf_state._omega;
+        m_csv << m_tireTMrf_state._omega;
+        m_csv << m_tireTMlr_state._omega;
+        m_csv << m_tireTMrr_state._omega;
+    } else {
+        m_csv << m_tireTMNrlf_state._omega;
+        m_csv << m_tireTMNrrf_state._omega;
+        m_csv << m_tireTMNrlr_state._omega;
+        m_csv << m_tireTMNrrr_state._omega;
+    }
+    m_csv << m_veh_state._tor / 4.;
+    m_csv << m_veh_state._current_gr + 1;
+    m_csv << m_veh_state._crankOmega;
+#ifdef DEBUG
+    m_csv << M_DEBUG_LF_TIRE_FX;
+    m_csv << M_DEBUG_RF_TIRE_FX;
+    m_csv << M_DEBUG_LR_TIRE_FX;
+    m_csv << M_DEBUG_RR_TIRE_FX;
+    m_csv << M_DEBUG_LF_TIRE_FY;
+    m_csv << M_DEBUG_RF_TIRE_FY;
+    m_csv << M_DEBUG_LR_TIRE_FY;
+    m_csv << M_DEBUG_RR_TIRE_FY;
+    m_csv << M_DEBUG_LF_TIRE_FZ;
+    m_csv << M_DEBUG_RF_TIRE_FZ;
+    m_csv << M_DEBUG_LR_TIRE_FZ;
+    m_csv << M_DEBUG_RR_TIRE_FZ;
+#endif
+    m_csv << std::endl;
+}
+
+// ======================================================================================================================
+
+void d18SolverHalfImplicitGPU::WriteToFile() {
+    if (!m_output) {
+        std::cout << "No output file specified. Call SetOutput() before calling WriteToFile()" << std::endl;
+        return;
+    }
+    m_csv.write_to_file(m_output_file);
+    m_csv.clearData();
+    m_timeStepsStored = 0;
+}
+
+// ======================================================================================================================
+
+// Utility functions for finite differencing
+
+void packY(const d18::VehicleState& v_states,
+           const d18::TMeasyState& tirelf_st,
+           const d18::TMeasyState& tirerf_st,
+           const d18::TMeasyState& tirelr_st,
+           const d18::TMeasyState& tirerr_st,
+           bool has_TC,
+           std::vector<double>& y) {
+    int index = 0;
+
+    // Tire deflections (lf, rf, lr and rr)
+
+    y[index++] = tirelf_st._xe;
+    y[index++] = tirelf_st._ye;
+    y[index++] = tirerf_st._xe;
+    y[index++] = tirerf_st._ye;
+    y[index++] = tirelr_st._xe;
+    y[index++] = tirelr_st._ye;
+    y[index++] = tirerr_st._xe;
+    y[index++] = tirerr_st._ye;
+
+    // Wheel angular velocities (lf, rf, lr and rr)
+    y[index++] = tirelf_st._omega;
+    y[index++] = tirerf_st._omega;
+    y[index++] = tirelr_st._omega;
+    y[index++] = tirerr_st._omega;
+
+    // Crank angular velocity - This is a state only when a torque converter is
+    // used
+    if (has_TC) {
+        y[index++] = v_states._crankOmega;
+    }
+
+    // Vehicle states
+    y[index++] = v_states._x;    // X position
+    y[index++] = v_states._y;    // Y position
+    y[index++] = v_states._u;    // longitudinal velocity
+    y[index++] = v_states._v;    // lateral velocity
+    y[index++] = v_states._psi;  // yaw angle
+    y[index++] = v_states._wz;   // yaw rate
+    y[index++] = v_states._phi;  // roll angle
+    y[index++] = v_states._wx;   // roll rate
+}
+
+void packY(const d18::VehicleState& v_states,
+           const d18::TMeasyNrState& tirelf_st,
+           const d18::TMeasyNrState& tirerf_st,
+           const d18::TMeasyNrState& tirelr_st,
+           const d18::TMeasyNrState& tirerr_st,
+           bool has_TC,
+           std::vector<double>& y) {
+    int index = 0;
+
+    // Wheel angular velocities (lf, rf, lr and rr)
+    y[index++] = tirelf_st._omega;
+    y[index++] = tirerf_st._omega;
+    y[index++] = tirelr_st._omega;
+    y[index++] = tirerr_st._omega;
+
+    // Crank angular velocity - This is a state only when a torque converter is
+    // used
+    if (has_TC) {
+        y[index++] = v_states._crankOmega;
+    }
+
+    // Vehicle states
+    y[index++] = v_states._x;    // X position
+    y[index++] = v_states._y;    // Y position
+    y[index++] = v_states._u;    // longitudinal velocity
+    y[index++] = v_states._v;    // lateral velocity
+    y[index++] = v_states._psi;  // yaw angle
+    y[index++] = v_states._wz;   // yaw rate
+    y[index++] = v_states._phi;  // roll angle
+    y[index++] = v_states._wx;   // roll rate
+}
+
+void packYDOT(const d18::VehicleState& v_states,
+              const d18::TMeasyState& tirelf_st,
+              const d18::TMeasyState& tirerf_st,
+              const d18::TMeasyState& tirelr_st,
+              const d18::TMeasyState& tirerr_st,
+              bool has_TC,
+              std::vector<double>& ydot) {
+    int index = 0;
+
+    ydot[index++] = tirelf_st._xedot;
+    ydot[index++] = tirelf_st._yedot;
+    ydot[index++] = tirerf_st._xedot;
+    ydot[index++] = tirerf_st._yedot;
+    ydot[index++] = tirelr_st._xedot;
+    ydot[index++] = tirelr_st._yedot;
+    ydot[index++] = tirerr_st._xedot;
+    ydot[index++] = tirerr_st._yedot;
+
+    ydot[index++] = tirelf_st._dOmega;
+    ydot[index++] = tirerf_st._dOmega;
+    ydot[index++] = tirelr_st._dOmega;
+    ydot[index++] = tirerr_st._dOmega;
+
+    if (has_TC) {
+        ydot[index++] = v_states._dOmega_crank;
+    }
+
+    ydot[index++] = v_states._dx;
+    ydot[index++] = v_states._dy;
+    ydot[index++] = v_states._udot;
+    ydot[index++] = v_states._vdot;
+    ydot[index++] = v_states._wz;
+    ydot[index++] = v_states._wzdot;
+    ydot[index++] = v_states._wx;
+    ydot[index++] = v_states._wxdot;
+}
+
+void packYDOT(const d18::VehicleState& v_states,
+              const d18::TMeasyNrState& tirelf_st,
+              const d18::TMeasyNrState& tirerf_st,
+              const d18::TMeasyNrState& tirelr_st,
+              const d18::TMeasyNrState& tirerr_st,
+              bool has_TC,
+              std::vector<double>& ydot) {
+    int index = 0;
+
+    ydot[index++] = tirelf_st._dOmega;
+    ydot[index++] = tirerf_st._dOmega;
+    ydot[index++] = tirelr_st._dOmega;
+    ydot[index++] = tirerr_st._dOmega;
+
+    if (has_TC) {
+        ydot[index++] = v_states._dOmega_crank;
+    }
+
+    ydot[index++] = v_states._dx;
+    ydot[index++] = v_states._dy;
+    ydot[index++] = v_states._udot;
+    ydot[index++] = v_states._vdot;
+    ydot[index++] = v_states._wz;
+    ydot[index++] = v_states._wzdot;
+    ydot[index++] = v_states._wx;
+    ydot[index++] = v_states._wxdot;
+}
+
+void unpackY(const std::vector<double>& y,
+             bool has_TC,
+             d18::VehicleState& v_states,
+             d18::TMeasyState& tirelf_st,
+             d18::TMeasyState& tirerf_st,
+             d18::TMeasyState& tirelr_st,
+             d18::TMeasyState& tirerr_st) {
+    int index = 0;
+    // Tire deflections
+    tirelf_st._xe = y[index++];
+    tirelf_st._ye = y[index++];
+    tirerf_st._xe = y[index++];
+    tirerf_st._ye = y[index++];
+    tirelr_st._xe = y[index++];
+    tirelr_st._ye = y[index++];
+    tirerr_st._xe = y[index++];
+    tirerr_st._ye = y[index++];
+
+    // Wheel angular velocities
+    tirelf_st._omega = y[index++];
+    tirerf_st._omega = y[index++];
+    tirelr_st._omega = y[index++];
+    tirerr_st._omega = y[index++];
+
+    // Crank angular velocity - This is a state only when a torque converter is
+    // used
+    if (has_TC) {
+        v_states._crankOmega = y[index++];
+    }
+
+    // Vehicle states
+    v_states._x = y[index++];    // X position
+    v_states._y = y[index++];    // Y position
+    v_states._u = y[index++];    // longitudinal velocity
+    v_states._v = y[index++];    // lateral velocity
+    v_states._psi = y[index++];  // yaw angle
+    v_states._wz = y[index++];   // yaw rate
+    v_states._phi = y[index++];  // roll angle
+    v_states._wx = y[index++];   // roll rate
+}
+
+void unpackY(const std::vector<double>& y,
+             bool has_TC,
+             d18::VehicleState& v_states,
+             d18::TMeasyNrState& tirelf_st,
+             d18::TMeasyNrState& tirerf_st,
+             d18::TMeasyNrState& tirelr_st,
+             d18::TMeasyNrState& tirerr_st) {
+    int index = 0;
+
+    // Wheel angular velocities
+    tirelf_st._omega = y[index++];
+    tirerf_st._omega = y[index++];
+    tirelr_st._omega = y[index++];
+    tirerr_st._omega = y[index++];
+
+    // Crank angular velocity - This is a state only when a torque converter is
+    // used
+    if (has_TC) {
+        v_states._crankOmega = y[index++];
+    }
+
+    // Vehicle states
+    v_states._x = y[index++];    // X position
+    v_states._y = y[index++];    // Y position
+    v_states._u = y[index++];    // longitudinal velocity
+    v_states._v = y[index++];    // lateral velocity
+    v_states._psi = y[index++];  // yaw angle
+    v_states._wz = y[index++];   // yaw rate
+    v_states._phi = y[index++];  // roll angle
+    v_states._wx = y[index++];   // roll rate
+}

--- a/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cu
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cu
@@ -81,7 +81,7 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
     unsigned int driver_data_len = driver_data.size();
     size_t old_vehicle_count = m_vehicle_count_tracker_params;
     m_vehicle_count_tracker_params += num_vehicles;
-    for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_params; i++) {
+    for (size_t i = old_vehicle_count; i < m_vehicle_count_tracker_params; i++) {
         m_sim_data[i]._driver_data_len = driver_data_len;
         // Allocate memory for the driver data
         CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_data[i]._driver_data,
@@ -92,7 +92,7 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
         m_sim_data[i]._veh_param = veh_param;
         m_sim_data[i]._tireTM_param = tire_param;
     }
-    CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
+    CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data, sizeof(m_sim_data[0]) * m_vehicle_count_tracker_params,
                                           0));  // move the simData onto the GPU
 }
 
@@ -130,7 +130,7 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
         unsigned int driver_data_len = driver_data.size();
         size_t old_vehicle_count = m_vehicle_count_tracker_params;
         m_vehicle_count_tracker_params += num_vehicles;
-        for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_params; i++) {
+        for (size_t i = old_vehicle_count; i < m_vehicle_count_tracker_params; i++) {
             m_sim_data[i]._driver_data_len = driver_data_len;
             // Allocate memory for the driver data
             CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_data[i]._driver_data,
@@ -141,7 +141,7 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
             m_sim_data[i]._veh_param = veh_param;
             m_sim_data[i]._tireTM_param = tire_param;
         }
-        CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
+        CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data, sizeof(m_sim_data[0]) * m_vehicle_count_tracker_params,
                                               0));  // move the simData onto the GPU
     } else {
         // Because of this, we free the memory of the TMeasyNR tire
@@ -166,7 +166,7 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
         unsigned int driver_data_len = driver_data.size();
         size_t old_vehicle_count = m_vehicle_count_tracker_params;
         m_vehicle_count_tracker_params += num_vehicles;
-        for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_params; i++) {
+        for (size_t i = old_vehicle_count; i < m_vehicle_count_tracker_params; i++) {
             m_sim_data_nr[i]._driver_data_len = driver_data_len;
             // Allocate memory for the driver data
             CHECK_CUDA_ERROR(cudaMallocManaged((void**)&m_sim_data_nr[i]._driver_data,
@@ -177,7 +177,7 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
             m_sim_data_nr[i]._veh_param = veh_param;
             m_sim_data_nr[i]._tireTMNr_param = tire_param;
         }
-        CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data_nr, sizeof(SimData) * m_vehicle_count_tracker_params,
+        CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data_nr, sizeof(m_sim_data_nr[0]) * m_vehicle_count_tracker_params,
                                               0));  // move the simData onto the GPU
     }
 }
@@ -210,13 +210,13 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
 
     size_t old_vehicle_count = m_vehicle_count_tracker_params;
     m_vehicle_count_tracker_params += num_vehicles;
-    for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_params; i++) {
+    for (size_t i = old_vehicle_count; i < m_vehicle_count_tracker_params; i++) {
         // Fill up simulation data from the cpu structs
         m_sim_data[i]._veh_param = veh_param;
         m_sim_data[i]._tireTM_param = tire_param;
     }
 
-    CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
+    CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data, sizeof(m_sim_data[0]) * m_vehicle_count_tracker_params,
                                           0));  // move the simData onto the GPU
 }
 
@@ -249,12 +249,12 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
 
         size_t old_vehicle_count = m_vehicle_count_tracker_params;
         m_vehicle_count_tracker_params += num_vehicles;
-        for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_params; i++) {
+        for (size_t i = old_vehicle_count; i < m_vehicle_count_tracker_params; i++) {
             // Fill up simulation data from the cpu structs
             m_sim_data[i]._veh_param = veh_param;
             m_sim_data[i]._tireTM_param = tire_param;
         }
-        CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data, sizeof(SimData) * m_vehicle_count_tracker_params,
+        CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data, sizeof(m_sim_data[0]) * m_vehicle_count_tracker_params,
                                               0));  // move the simData onto the GPU
     } else {
         // Because of this, we free the memory of the TMeasyNR tire
@@ -276,12 +276,12 @@ __host__ void d18SolverHalfImplicitGPU::Construct(const std::string& vehicle_par
 
         size_t old_vehicle_count = m_vehicle_count_tracker_params;
         m_vehicle_count_tracker_params += num_vehicles;
-        for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_params; i++) {
+        for (size_t i = old_vehicle_count; i < m_vehicle_count_tracker_params; i++) {
             // Fill up simulation data from the cpu structs
             m_sim_data_nr[i]._veh_param = veh_param;
             m_sim_data_nr[i]._tireTMNr_param = tire_param;
         }
-        CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data_nr, sizeof(SimData) * m_vehicle_count_tracker_params,
+        CHECK_CUDA_ERROR(cudaMemPrefetchAsync(m_sim_data_nr, sizeof(m_sim_data_nr[0]) * m_vehicle_count_tracker_params,
                                               0));  // move the simData onto the GPU
     }
 }
@@ -300,7 +300,7 @@ __host__ void d18SolverHalfImplicitGPU::Initialize(d18::VehicleState& vehicle_st
            "Number of vehicles added makes the vehicle count greater than the total number of vehicles");
     size_t old_vehicle_count = m_vehicle_count_tracker_states;
     m_vehicle_count_tracker_states += num_vehicles;
-    for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_states; i++) {
+    for (size_t i = old_vehicle_count; i < m_vehicle_count_tracker_states; i++) {
         // Fill up simulation data from the cpu structs
         m_sim_states[i]._veh_state = vehicle_states;
         m_sim_states[i]._tirelf_state = tire_states_LF;
@@ -326,7 +326,7 @@ __host__ void d18SolverHalfImplicitGPU::Initialize(d18::VehicleState& vehicle_st
            "Number of vehicles added makes the vehicle count greater than the total number of vehicles");
     size_t old_vehicle_count = m_vehicle_count_tracker_states;
     m_vehicle_count_tracker_states += num_vehicles;
-    for (size_t i = old_vehicle_count; i <= m_vehicle_count_tracker_states; i++) {
+    for (size_t i = old_vehicle_count; i < m_vehicle_count_tracker_states; i++) {
         // Fill up simulation data from the cpu structs
         m_sim_states_nr[i]._veh_state = vehicle_states;
         m_sim_states_nr[i]._tirelf_state = tire_states_LF;

--- a/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cuh
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cuh
@@ -1,0 +1,241 @@
+#ifndef DOF18_HALFIMPLICIT_H
+#define DOF18_HALFIMPLICIT_H
+
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "dof18_gpu.cuh"
+
+// =============================================================================
+// Define the solver class
+// =============================================================================
+class d18SolverHalfImplicitGPU {
+  public:
+    /// @brief Initialize the solver with the total number of vehicles to be simulated
+    __device__ __host__ d18SolverHalfImplicitGPU(unsigned int total_num_vehicles);
+    __device__ __host__ ~d18SolverHalfImplicitGPU();
+
+    /// @brief Construct the solver using path to vehicle parameters, tire parameters, number of vehicles and driver
+    /// inputs. Each of these vehicles will have the specified parameters and driver inputs. To add more vehicles
+    /// (ensuring they are still lesser than the total number of vehicles initally specified in the class constructor)
+    /// with different parameters, call the Construct function again. The tire type defaults to TMeasy
+    /// @param vehicle_params_file Path to the vehicle parameter json file
+    /// @param tire_params_file Path to the tire parameter json file
+    /// @param num_vehicles Number of vehicles to be simulated with the specified parameters and driver inputs
+    /// @param driver_inputs_file Path to the driver inputs text file
+    __host__ void Construct(const std::string& veh_params_file,
+                            const std::string& tire_params_file,
+                            unsigned int num_vehicles,
+                            const std::string& driver_file);
+
+    /// @brief Construct the the solver using path to vehicle parameters, tire parameters, number of vehicles, driver
+    /// inputs and the TireType (Either TMEasy or TMEasyNr). Each of these vehicles will have the specified parameters
+    /// and driver inputs. To add more vehicles with different parameters, call the Construct function again.
+    /// @param vehicle_params_file Path to the vehicle parameter json file
+    /// @param tire_params_file Path to the tire parameter json file
+    /// @param num_vehicles Number of vehicles to be simulated with the specified parameters and driver inputs
+    /// @param driver_inputs_file Path to the driver inputs text file
+    /// @param type TireType (Either TMEasy or TMEasyNr)
+    __host__ void Construct(const std::string& vehicle_params_file,
+                            const std::string& tire_params_file,
+                            unsigned int num_vehicles,
+                            const std::string& driver_inputs_file,
+                            TireType type);
+    /// @brief Construct the the solver using path to vehicle parameters, tire parameters, number of vehicles. TireType
+    /// defualts to TMEasy tires. Each of these vehicles will have the specified parameters. This is mainly provided for
+    /// cases where the driver inputs are not available at the start of the simulation but rather come from a controller
+    /// during the simualtion. To add more vehicles with different parameters, call the Construct function again.
+    /// @param vehicle_params_file Path to the vehicle parameter json file
+    /// @param tire_params_file Path to the tire parameter json file
+    /// @param num_vehicles Number of vehicles to be simulated with the specified parameters and driver inputs
+    __host__ void Construct(const std::string& vehicle_params_file,
+                            const std::string& tire_params_file,
+                            unsigned int num_vehicles);
+    /// @brief Construct the the solver using path to vehicle parameters, tire parameters, number of vehicles and the
+    /// TireType (Either TMEasy or TMEasyNr). Each of these vehicles will have the specified parameters. This is mainly
+    /// provided for cases where the driver inputs are not available at the start of the simulation but rather come from
+    /// a controller during the simualtion. To add more vehicles with different parameters, call the Construct
+    /// function again.
+    /// @param vehicle_params_file Path to the vehicle parameter json file
+    /// @param tire_params_file Path to the tire parameter json file
+    /// @param num_vehicles Number of vehicles to be simulated with the specified parameters and driver inputs
+    /// @param type TireType (Either TMEasy or TMEasyNr)
+    __host__ void Construct(const std::string& vehicle_params_file,
+                            const std::string& tire_params_file,
+                            unsigned int num_vehicles,
+                            TireType type);
+
+    // Set the solver time step
+    __host__ void SetTimeStep(double step) { m_step = step; }
+
+    __host__ __device__ double GetStep() { return m_step; }
+
+    __host__ __device__ DriverData GetDriverData() { return m_driver_data; }
+
+    // Jacobian getter functions
+    double** GetJacobianState() { return m_jacobian_state; }
+    double** GetJacobianControls() { return m_jacobian_controls; }
+
+    /// @brief Switch on output to a csv file at the specified frequency.
+    /// @param output_file Path to the output file
+    /// @param output_freq Frequency of data output
+    /// @param store_all Flag to store data from each vehicle on all the threads or no_outs vehicles
+    /// @param no_outs Number of outputs to store if store_all is false
+    __host__ void SetOutput(const std::string& output_file,
+                            double output_freq,
+                            bool store_all = false,
+                            unsigned int no_outs = 50);
+
+    /// @brief Solve the system of equations by calling the integrate function
+    void Solve();
+
+    /// @brief Initialize vehicle and tire states. This function has to be called before solve and after construct.
+    /// Although it is possible to provide non-zero intial states, this is untested and it is recommended to use the
+    /// default zero states. To initialize more vehicles, call the Initialize function again.
+    /// @param vehicle_states Vehicle states
+    /// @param tire_states_LF Left Front (LF) TMeasy tire states
+    /// @param tire_states_RF Right Front (RF) TMeasy tire states
+    /// @param tire_states_LR Left Rear (LR) TMeasy tire states
+    /// @param tire_states_RR Right Rear (RR) TMeasy tire states
+    /// @param num_vehicles Number of vehicles to be simulated with the specified states
+    __host__ void Initialize(d18::VehicleState& vehicle_states,
+                             d18::TMeasyState& tire_states_LF,
+                             d18::TMeasyState& tire_states_RF,
+                             d18::TMeasyState& tire_states_LR,
+                             d18::TMeasyState& tire_states_RR,
+                             unsigned int num_vehicles);
+    /// @brief Initialize vehicle and tire states. This function has to be called before solve and after construct.
+    /// Although it is possible to provide non-zero intial states, this is untested and it is recommended to use the
+    /// default zero states. To initialize more vehicles, call the Initialize function again.
+    /// @param vehicle_states Vehicle states
+    /// @param tire_states_LF Left Front (LF) TMeasyNr tire states
+    /// @param tire_states_RF Right Front (RF) TMeasyNr tire states
+    /// @param tire_states_LR Left Rear (LR) TMeasyNr tire states
+    /// @param tire_states_RR Right Rear (RR) TMeasyNr tire states
+    /// @param num_vehicles Number of vehicles to be simulated with the specified states
+    __host__ void Initialize(d18::VehicleState& vehicle_states,
+                             d18::TMeasyNrState& tire_states_LF,
+                             d18::TMeasyNrState& tire_states_RF,
+                             d18::TMeasyNrState& tire_states_LR,
+                             d18::TMeasyNrState& tire_states_RR,
+                             unsigned int num_vehicles);
+    /// @brief Integrate from t to tend with the specified controls
+    /// @param t Current time (ideally that returned by IntegrateStep)
+    /// @param step Step to take. Note, integration internally will still happen at the time step set by the user or the
+    /// default 1e-3. This step here is to improve GPU efficiency by taking multiple steps at once.
+    /// @param throttle Applied throttle
+    /// @param steering Applied steering
+    /// @param braking Applied braking
+    /// @return Current time after integration
+    double IntegrateStep(double t, double step, double throttle, double steering, double braking);
+
+    // TODO: This would require dynamic parallelism and is thus left for later
+    double IntegrateStepWithJacobian(double t, double throttle, double steering, double braking, bool on);
+
+    /// @brief When using the IntegrateStep, once the integration is complete, this function can be used to Write the
+    /// output to a file specified by the user in the SetOutput function.
+    void WriteToFile();
+
+    /// @brief Get Tire type
+    /// @return Tire type used in the solver
+    TireType GetTireType() const { return m_tire_type; }
+
+    __global__ d18::SimData* m_sim_data;          ///< Simulation data for all the vehicles
+    __global__ d18::SimDataNr* m_sim_data_nr;     ///< Simulation data but with the TMeasyNr tire for all the vehicles
+    __global__ d18::SimState* m_sim_states;       ///< Simulation states for all the vehicles
+    __global__ d18::SimStateNr* m_sim_states_nr;  ///< Simulation states but with the TMeasyNr tire for all the vehicles
+
+  private:
+    void Integrate();
+
+    void Write(double t);
+
+    void rhsFun(double t);
+
+    void rhsFun(double t, DriverInput& controls);  // We need to provide controls when we are stepping
+
+    // For finite differencing for applications in MPC to perturb either controls or y
+    void PerturbRhsFun(std::vector<double>& y, DriverInput& controls, std::vector<double>& ydot);
+
+    TireType m_tire_type;                         // Tire type
+    CSV_writer m_csv;                             // CSV writer object
+    double m_step;                                // integration time step
+    int m_timeStepsStored;                        // Keeps track of time steps stored if we need data output
+    bool m_output;                                // data output flag
+    double m_dtout;                               // time interval between data output
+    std::string m_output_file;                    // output file path
+    DriverData m_driver_data;                     // driver inputs
+    int m_num_controls;                           // Number of control states for jacobian
+    int m_num_states;                             // Number of states for jacobian
+    unsigned int m_total_num_vehicles;            // Number of vehicles
+    unsigned int m_vehicle_count_tracker_params;  // Keeps track of number of vehicles initialized to ensure that total
+                                                  // vehicles match with the vehicles initialized through construct and
+                                                  // initialize. This is for construct which initializes parameters.
+                                                  // There is another one for states
+    unsigned int m_vehicle_count_tracker_states;  // Keeps track of number of vehicles initialized to ensure that total
+    // Jacobian matrix incase user needs finite differencing -> This probably needs to move into the simState struct
+    double** m_jacobian_state;
+    double** m_jacobian_controls;
+
+    // Device and host response vectors that contain all the states from all the vehicles at all the timesteps -> This
+    // is not to be used by the user, but rather is used internally to write to file
+    double* device_response;
+    double* device_response_nr;
+    double* host_response;
+    double* host_response_nr;
+};
+
+#ifndef SWIG
+// Utility functions to help with finite differencing
+void packY(const d18::VehicleState& v_states,
+           const d18::TMeasyState& tirelf_st,
+           const d18::TMeasyState& tirerf_st,
+           const d18::TMeasyState& tirelr_st,
+           const d18::TMeasyState& tirerr_st,
+           bool has_TC,
+           std::vector<double>& y);
+void packY(const d18::VehicleState& v_states,
+           const d18::TMeasyNrState& tirelf_st,
+           const d18::TMeasyNrState& tirerf_st,
+           const d18::TMeasyNrState& tirelr_st,
+           const d18::TMeasyNrState& tirerr_st,
+           bool has_TC,
+           std::vector<double>& y);
+
+void packYDOT(const d18::VehicleState& v_states,
+              const d18::TMeasyState& tirelf_st,
+              const d18::TMeasyState& tirerf_st,
+              const d18::TMeasyState& tirelr_st,
+              const d18::TMeasyState& tirerr_st,
+              bool has_TC,
+              std::vector<double>& ydot);
+
+void packYDOT(const d18::VehicleState& v_states,
+              const d18::TMeasyNrState& tirelf_st,
+              const d18::TMeasyNrState& tirerf_st,
+              const d18::TMeasyNrState& tirelr_st,
+              const d18::TMeasyNrState& tirerr_st,
+              bool has_TC,
+              std::vector<double>& ydot);
+
+void unpackY(const std::vector<double>& y,
+             bool has_TC,
+             d18::VehicleState& v_states,
+             d18::TMeasyState& tirelf_st,
+             d18::TMeasyState& tirerf_st,
+             d18::TMeasyState& tirelr_st,
+             d18::TMeasyState& tirerr_st);
+
+void unpackY(const std::vector<double>& y,
+             bool has_TC,
+             d18::VehicleState& v_states,
+             d18::TMeasyNrState& tirelf_st,
+             d18::TMeasyNrState& tirerf_st,
+             d18::TMeasyNrState& tirelr_st,
+             d18::TMeasyNrState& tirerr_st);
+
+#endif
+
+#endif

--- a/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cuh
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cuh
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <vector>
+#include <memory>
 
 #include "dof18_gpu.cuh"
 
@@ -195,6 +196,9 @@ class d18SolverHalfImplicitGPU {
     // is not to be used by the user, but rather is used internally to write to file
     double* m_device_response;
     double* m_host_response;
+
+    // Need a bunch of csv writers for each of the vehicles. We will store a pointer to this list
+    std::unique_ptr<CSV_writer[]> m_csv_writers_ptr;
 };
 
 // Cannout have global function as class member function

--- a/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cuh
+++ b/wheeled_vehicle_models/18dof-gpu/dof18_halfImplicit_gpu.cuh
@@ -131,6 +131,11 @@ class d18SolverHalfImplicitGPU {
     /// output to a file specified by the user in the SetOutput function.
     __host__ void WriteToFile();
 
+    /// @brief Get a SimState object for a particular vehicle
+    /// @param vehicle_index Index of the vehicle
+    /// @return SimState object for the vehicle
+    __host__ d18::SimState GetSimState(unsigned int vehicle_index);
+
     /// @brief Get Tire type
     /// @return Tire type used in the solver
     TireType GetTireType() const { return m_tire_type; }
@@ -154,7 +159,7 @@ class d18SolverHalfImplicitGPU {
                               // the user
 
   private:
-    __host__ void Write(double t);
+    __host__ void Write(double t, unsigned int time_steps_to_write = 0);
 
     TireType m_tire_type;  // Tire type
     double m_step;         // integration time step

--- a/wheeled_vehicle_models/utils/utils_gpu.cu
+++ b/wheeled_vehicle_models/utils/utils_gpu.cu
@@ -1,0 +1,122 @@
+#include <fstream>
+#include <sstream>
+#include "utils_gpu.cuh"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+/// Driver inputs from data file.
+/// A driver model based on user inputs provided as time series. If provided as a
+/// text file, each line in the file must contain 4 values:
+///   time steering throttle braking
+/// It is assumed that the time values are unique and soted from 0 to T
+__host__ void LoadDriverData(DriverData& data, const std::string& filename) {
+    std::ifstream ifile(filename.c_str());
+    std::string line;
+
+    // get each line
+    while (std::getline(ifile, line)) {
+        std::istringstream iss(line);
+
+        double time, steering, throttle, braking;
+        iss >> time >> steering >> throttle >> braking;
+
+        if (iss.fail())
+            break;
+
+        // push into our structure
+        data.push_back(DriverInput(time, steering, throttle, braking));
+    }
+
+    ifile.close();
+}
+
+// Function to get the vehicle controls at a given time
+__device__ DriverInput GetDriverInput(double time, const DriverInput* driver_data, const unsigned int data_length) {
+    DriverInput input;
+
+    if (time <= driver_data[0].m_time) {
+        input = driver_data[0];
+    } else if (time >= driver_data[data_length].m_time) {
+        input = driver_data[data_length];
+    } else {
+        // if time is within map range, get an iterator and do linear interpolation
+        int right = lower_bound(driver_data, data_length, DriverInput(time, 0, 0, 0));
+        int left = right - 1;
+
+        double tbar = (time - driver_data[left].m_time) / (driver_data[right].m_time - driver_data[left].m_time);
+        input.m_time = time;
+        input.m_steering =
+            driver_data[left].m_steering + tbar * (driver_data[right].m_steering - driver_data[left].m_steering);
+        input.m_throttle =
+            driver_data[left].m_throttle + tbar * (driver_data[right].m_throttle - driver_data[left].m_throttle);
+        input.m_braking =
+            driver_data[left].m_braking + tbar * (driver_data[right].m_braking - driver_data[left].m_braking);
+    }
+    return input;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+__device__ double getMapY(const MapEntry* map, const double x, const unsigned int map_size) {
+    // if x outside map range
+    if (x <= map[0]._x) {
+        return map[0]._y;
+    } else if (x >= map[map_size]._x) {
+        return map[map_size]._y;
+    }
+
+    // if x within map range, get an iterator and do linear interpolation
+
+    int right = lower_bound_map(map, map_size, MapEntry(x, 0));
+    int left = right - 1;
+
+    // linear interplolation
+    double mbar = (x - map[left]._x) / (map[right]._x - map[left]._x);
+    return (map[left]._y + mbar * (map[right]._y - map[left]._y));
+}
+
+// sine step function for some smoothing operations
+__device__ double sineStep(double x, double x1, double y1, double x2, double y2) {
+    if (x <= x1)
+        return y1;
+    if (x >= x2)
+        return y2;
+
+    double dx = x2 - x1;
+    double dy = y2 - y1;
+    double y = y1 + dy * (x - x1) / dx - (dy / C_2PI) * std::sin(C_2PI * (x - x1) / dx);
+    return y;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+// utility function to std::lower_bound on device
+// Implementing lower bound c++ function in C with our custom container "Entry"
+// Just a binary search
+__device__ unsigned int lower_bound(const DriverInput* a, unsigned int n, DriverInput x) {
+    int l = 0;
+    int h = n;  // not sure if this should be n or n-1
+    while (l < h) {
+        int mid = l + (h - l) / 2;
+        if (x.m_time <= a[mid].m_time) {
+            h = mid;
+        } else {
+            l = mid + 1;
+        }
+    }
+    return l;
+}
+
+__device__ unsigned int lower_bound_map(const MapEntry* a, unsigned int n, MapEntry x) {
+    int l = 0;
+    int h = n;
+    while (l < h) {
+        int mid = l + (h - l) / 2;
+        if (x._x <= a[mid]._x) {
+            h = mid;
+        } else {
+            l = mid + 1;
+        }
+    }
+    return l;
+}

--- a/wheeled_vehicle_models/utils/utils_gpu.cu
+++ b/wheeled_vehicle_models/utils/utils_gpu.cu
@@ -13,6 +13,11 @@ __host__ void LoadDriverData(DriverData& data, const std::string& filename) {
     std::ifstream ifile(filename.c_str());
     std::string line;
 
+    if (!ifile) {
+        std::cerr << "Error opening file: " << filename << std::endl;
+        return;
+    }
+
     // get each line
     while (std::getline(ifile, line)) {
         std::istringstream iss(line);

--- a/wheeled_vehicle_models/utils/utils_gpu.cu
+++ b/wheeled_vehicle_models/utils/utils_gpu.cu
@@ -41,8 +41,8 @@ __device__ DriverInput GetDriverInput(double time, const DriverInput* driver_dat
 
     if (time <= driver_data[0].m_time) {
         input = driver_data[0];
-    } else if (time >= driver_data[data_length].m_time) {
-        input = driver_data[data_length];
+    } else if (time >= driver_data[data_length - 1].m_time) {
+        input = driver_data[data_length - 1];
     } else {
         // if time is within map range, get an iterator and do linear interpolation
         int right = lower_bound(driver_data, data_length, DriverInput(time, 0, 0, 0));
@@ -66,15 +66,14 @@ __device__ double getMapY(const MapEntry* map, const double x, const unsigned in
     // if x outside map range
     if (x <= map[0]._x) {
         return map[0]._y;
-    } else if (x >= map[map_size]._x) {
-        return map[map_size]._y;
+    } else if (x >= map[map_size - 1]._x) {
+        return map[map_size - 1]._y;
     }
 
     // if x within map range, get an iterator and do linear interpolation
 
     int right = lower_bound_map(map, map_size, MapEntry(x, 0));
     int left = right - 1;
-
     // linear interplolation
     double mbar = (x - map[left]._x) / (map[right]._x - map[left]._x);
     return (map[left]._y + mbar * (map[right]._y - map[left]._y));

--- a/wheeled_vehicle_models/utils/utils_gpu.cuh
+++ b/wheeled_vehicle_models/utils/utils_gpu.cuh
@@ -98,63 +98,63 @@ __device__ T clamp(T value, T limitMin, T limitMax) {
 
 // --------------------------------------------------------------------------------------------------------------------
 
-// class CSV_writer {
-//   public:
-//     explicit CSV_writer(const std::string& delim = ",") : m_delim(delim) {}
+class CSV_writer {
+  public:
+    explicit CSV_writer(const std::string& delim = ",") : m_delim(delim) {}
 
-//     CSV_writer(const CSV_writer& source) : m_delim(source.m_delim) {
-//         // Note that we do not copy the stream buffer (as then it would be shared!)
-//         m_ss.copyfmt(source.m_ss);          // copy all data
-//         m_ss.clear(source.m_ss.rdstate());  // copy the error state
-//     }
+    CSV_writer(const CSV_writer& source) : m_delim(source.m_delim) {
+        // Note that we do not copy the stream buffer (as then it would be shared!)
+        m_ss.copyfmt(source.m_ss);          // copy all data
+        m_ss.clear(source.m_ss.rdstate());  // copy the error state
+    }
 
-//     ~CSV_writer() {}
+    ~CSV_writer() {}
 
-//     void write_to_file(const std::string& filename, const std::string& header = "") const {
-//         std::ofstream ofile(filename.c_str());
-//         ofile << header;
-//         ofile << m_ss.str();
-//         ofile.close();
-//     }
+    void write_to_file(const std::string& filename, const std::string& header = "") const {
+        std::ofstream ofile(filename.c_str());
+        ofile << header;
+        ofile << m_ss.str();
+        ofile.close();
+    }
 
-//     // To clear the stream buffer
-//     void clearData() {
-//         m_ss.str("");  // Set the content of the stream buffer to an empty string
-//         m_ss.clear();  // Clear any error flags that might have been set
-//     }
+    // To clear the stream buffer
+    void clearData() {
+        m_ss.str("");  // Set the content of the stream buffer to an empty string
+        m_ss.clear();  // Clear any error flags that might have been set
+    }
 
-//     const std::string& delim() const { return m_delim; }
-//     std::ostringstream& stream() { return m_ss; }
+    const std::string& delim() const { return m_delim; }
+    std::ostringstream& stream() { return m_ss; }
 
-//     template <typename T>
-//     CSV_writer& operator<<(const T& t) {
-//         m_ss << t << m_delim;
-//         return *this;
-//     }
+    template <typename T>
+    CSV_writer& operator<<(const T& t) {
+        m_ss << t << m_delim;
+        return *this;
+    }
 
-//     CSV_writer& operator<<(std::ostream& (*t)(std::ostream&)) {
-//         m_ss << t;
-//         return *this;
-//     }
-//     CSV_writer& operator<<(std::ios& (*t)(std::ios&)) {
-//         m_ss << t;
-//         return *this;
-//     }
-//     CSV_writer& operator<<(std::ios_base& (*t)(std::ios_base&)) {
-//         m_ss << t;
-//         return *this;
-//     }
+    CSV_writer& operator<<(std::ostream& (*t)(std::ostream&)) {
+        m_ss << t;
+        return *this;
+    }
+    CSV_writer& operator<<(std::ios& (*t)(std::ios&)) {
+        m_ss << t;
+        return *this;
+    }
+    CSV_writer& operator<<(std::ios_base& (*t)(std::ios_base&)) {
+        m_ss << t;
+        return *this;
+    }
 
-//   private:
-//     std::string m_delim;
-//     std::ostringstream m_ss;
-// };
+  private:
+    std::string m_delim;
+    std::ostringstream m_ss;
+};
 
-// template <typename T>
-// inline CSV_writer& operator<<(CSV_writer& out, const std::vector<T>& vec) {
-//     for (const auto& v : vec)
-//         out << v;
-//     return out;
-// }
+template <typename T>
+inline CSV_writer& operator<<(CSV_writer& out, const std::vector<T>& vec) {
+    for (const auto& v : vec)
+        out << v;
+    return out;
+}
 
 #endif

--- a/wheeled_vehicle_models/utils/utils_gpu.cuh
+++ b/wheeled_vehicle_models/utils/utils_gpu.cuh
@@ -1,0 +1,160 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <fstream>
+#include <cuda.h>
+#include <vector>
+static const double C_PI = 3.141592653589793238462643383279;
+static const double C_2PI = 6.283185307179586476925286766559;
+static const double G = 9.81;  // gravity constant
+static const double rpm2rad = C_PI / 30;
+
+// --------------------------------------------------------------------------------------------------------------------
+// error checking macros
+
+#define CHECK_CUDA_ERROR(val) check((val), #val, __FILE__, __LINE__)
+template <typename T>
+void check(T err, const char* const func, const char* const file, const int line) {
+    if (err != cudaSuccess) {
+        std::cerr << "CUDA Runtime Error at: " << file << ":" << line << std::endl;
+        std::cerr << cudaGetErrorString(err) << " " << func << std::endl;
+    }
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+// Structure for storing driver input - Similar to Chrono
+struct DriverInput {
+    __device__ __host__ DriverInput() : m_time(0), m_steering(0), m_throttle(0), m_braking(0) {}
+    __device__ __host__ DriverInput(double time, double steering, double throttle, double braking)
+        : m_time(time), m_steering(steering), m_throttle(throttle), m_braking(braking) {}
+
+    // static bool compare(const DriverInput& a, const DriverInput& b) { return a.m_time < b.m_time; };
+
+    double m_time;
+    double m_steering;
+    double m_throttle;
+    double m_braking;
+};
+
+typedef std::vector<DriverInput> DriverData;
+
+// Driver inputs from data file.
+__host__ void LoadDriverData(DriverData& m_data, const std::string& filename);
+
+// Function to get the vehicle controls at a given time
+__device__ DriverInput GetDriverInput(double time, const DriverInput* driver_data, const unsigned int data_length);
+
+// --------------------------------------------------------------------------------------------------------------------
+
+// Structure for entries of any kind of map (anything with x and y)
+struct MapEntry {
+    __device__ __host__ MapEntry() : _x(0), _y(0) {}
+    __device__ __host__ MapEntry(double x, double y) : _x(x), _y(y) {}
+
+    // static bool compare(const MapEntry& a, const MapEntry& b) { return a._x < b._x; };
+
+    double _x;  // x coordinate of the map
+    double _y;  // y coordinate of the map
+};
+
+// Function to get the Y of the map by linear interpolation
+__device__ double getMapY(const MapEntry* map, const double x, const unsigned int map_size);
+
+// custom lower bound function for entry and map entry needed during interpolation
+__device__ unsigned int lower_bound(const DriverInput* a, unsigned int n, DriverInput x);
+__device__ unsigned int lower_bound_map(const MapEntry* a, unsigned int n, MapEntry x);
+
+// --------------------------------------------------------------------------------------------------------------------
+
+// linear interpolation function
+__device__ __host__ inline double InterpL(double fz, double w1, double w2, double pn) {
+    return w1 + (w2 - w1) * (fz / pn - 1.);
+}
+
+// quadratic interpolation function
+__device__ __host__ inline double InterpQ(double fz, double w1, double w2, double pn) {
+    return (fz / pn) * (2. * w1 - 0.5 * w2 - (w1 - 0.5 * w2) * (fz / pn));
+}
+
+// template safe signum function
+template <typename T>
+__device__ int sgn(T val) {
+    return (T(0) < val) - (val < T(0));
+}
+
+__device__ double sineStep(double x, double x1, double y1, double x2, double y2);
+
+// clamp function from chrono
+template <typename T>
+__device__ T clamp(T value, T limitMin, T limitMax) {
+    if (value < limitMin)
+        return limitMin;
+    if (value > limitMax)
+        return limitMax;
+
+    return value;
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
+// class CSV_writer {
+//   public:
+//     explicit CSV_writer(const std::string& delim = ",") : m_delim(delim) {}
+
+//     CSV_writer(const CSV_writer& source) : m_delim(source.m_delim) {
+//         // Note that we do not copy the stream buffer (as then it would be shared!)
+//         m_ss.copyfmt(source.m_ss);          // copy all data
+//         m_ss.clear(source.m_ss.rdstate());  // copy the error state
+//     }
+
+//     ~CSV_writer() {}
+
+//     void write_to_file(const std::string& filename, const std::string& header = "") const {
+//         std::ofstream ofile(filename.c_str());
+//         ofile << header;
+//         ofile << m_ss.str();
+//         ofile.close();
+//     }
+
+//     // To clear the stream buffer
+//     void clearData() {
+//         m_ss.str("");  // Set the content of the stream buffer to an empty string
+//         m_ss.clear();  // Clear any error flags that might have been set
+//     }
+
+//     const std::string& delim() const { return m_delim; }
+//     std::ostringstream& stream() { return m_ss; }
+
+//     template <typename T>
+//     CSV_writer& operator<<(const T& t) {
+//         m_ss << t << m_delim;
+//         return *this;
+//     }
+
+//     CSV_writer& operator<<(std::ostream& (*t)(std::ostream&)) {
+//         m_ss << t;
+//         return *this;
+//     }
+//     CSV_writer& operator<<(std::ios& (*t)(std::ios&)) {
+//         m_ss << t;
+//         return *this;
+//     }
+//     CSV_writer& operator<<(std::ios_base& (*t)(std::ios_base&)) {
+//         m_ss << t;
+//         return *this;
+//     }
+
+//   private:
+//     std::string m_delim;
+//     std::ostringstream m_ss;
+// };
+
+// template <typename T>
+// inline CSV_writer& operator<<(CSV_writer& out, const std::vector<T>& vec) {
+//     for (const auto& v : vec)
+//         out << v;
+//     return out;
+// }
+
+#endif

--- a/wheeled_vehicle_models/utils/utils_gpu.cuh
+++ b/wheeled_vehicle_models/utils/utils_gpu.cuh
@@ -4,6 +4,9 @@
 #include <fstream>
 #include <cuda.h>
 #include <vector>
+#include <iostream>
+#include <sstream>
+
 static const double C_PI = 3.141592653589793238462643383279;
 static const double C_2PI = 6.283185307179586476925286766559;
 static const double G = 9.81;  // gravity constant
@@ -20,7 +23,6 @@ void check(T err, const char* const func, const char* const file, const int line
         std::cerr << cudaGetErrorString(err) << " " << func << std::endl;
     }
 }
-
 // --------------------------------------------------------------------------------------------------------------------
 
 // Structure for storing driver input - Similar to Chrono


### PR DESCRIPTION
Added the GPU model for the 18DOF with demos. The model has been tested for correctness vs the CPU version. There are some features that are not available in the GPU model that are available in the CPU version. These include
1) Sundials integrator not supported
2) No Control and State Jacobians via Finite Differences (no IntegrateStepWithJacobian function as in CPU)
However, the GPU model has the following capabilities
1) Can simulate up to 300,000 vehicles with different parameters and different controls in real-time. 
2) Options to either run the entire simulation with compile time controls provided in a text file or to step the solver at the control frequency with vehicle controls defined at run-time. There is also the option of passing a functor to SolveStep that computes the controls within the GPU kernel. 